### PR TITLE
Ensure local certs created where expected

### DIFF
--- a/script/create_local_certs
+++ b/script/create_local_certs
@@ -2,6 +2,9 @@
 
 # This will create some self-signed certificates in the ssl folder
 
-cd ssl
-openssl req -x509 -out local.crt -keyout local.key -newkey rsa:2048 -nodes -sha256 -subj '/CN=localhost'
-cd ..
+set -e
+
+ssl_dir="$(dirname "$0")/../ssl"
+mkdir -p "$ssl_dir"
+
+openssl req -x509 -out "$ssl_dir/local.crt" -keyout "$ssl_dir/local.key" -newkey rsa:2048 -nodes -sha256 -subj '/CN=localhost'


### PR DESCRIPTION
If the SSL directory did not exist, it was not created and the cd
failed. This resulted in the certificates being placed in the current
directory instead. The secure_server script loads the certificates
specifically from the ssl/ folder. That directory needs to be created
and the certificates need to be stored there. There is not a particular
need to cd; this can be done instead with just specifying that directory
in the openssl arguments.

Resolves: AT-5913