### PR TITLE
Ensure dev DOD IDs are 10 digits

### DIFF
--- a/atat/routes/saml_helpers.py
+++ b/atat/routes/saml_helpers.py
@@ -1,5 +1,6 @@
+import random
 import re
-from random import randint
+import string
 from urllib.parse import urlparse
 
 import cachetools.func
@@ -129,7 +130,11 @@ def _validate_saml_assertion(saml_auth):
 
 
 def unique_dod_id():
-    new_dod_id = f"{randint(0,99999999):09}"  # nosec
+    """
+    Generate a new DOD ID for a development user.
+    """
+    # Ensure that the identifier always starts with a leading 0
+    new_dod_id = "".join(random.choices(string.digits, k=9)).zfill(10)  # nosec
     try:
         Users.get_by_dod_id(new_dod_id)
     except NotFoundError:

--- a/tests/routes/test_saml_helpers.py
+++ b/tests/routes/test_saml_helpers.py
@@ -1,3 +1,4 @@
+import re
 from unittest.mock import Mock, patch
 
 import pytest
@@ -14,6 +15,7 @@ from atat.routes.saml_helpers import (
     _validate_saml_assertion,
     init_saml_auth,
     init_saml_auth_dev,
+    unique_dod_id,
 )
 from tests.factories import UserFactory
 
@@ -85,6 +87,11 @@ def test_validate_saml_assertion_valid_with_errors(mock_logger):
 
     assert session["AuthNRequestID"] == "ABC123"
     mock_last_err.assert_called()
+
+
+def test_unique_dod_id_10_digits():
+    dod_id_regex = re.compile(r"\d{10}")
+    assert dod_id_regex.match(unique_dod_id())
 
 
 def create_saml_auth_mock(validation_result=None):


### PR DESCRIPTION
More expressedly choosing the a set of 9 digits seems like the intent is
clearer than choosing a random number between 0 and a magic number based
on the digits. The previous behavior was to always have at least one
leading zero so that constraint is preserved.

Resolves: AT-5914