### PR TITLE
Fix Vue test failure

### DIFF
--- a/js/components/__tests__/date_selector.test.js
+++ b/js/components/__tests__/date_selector.test.js
@@ -161,6 +161,8 @@ describe('DateSelector', () => {
 
     it('returns true if year is present', () => {
       component.year = new Date().getFullYear()
+      component.mindate = ''
+      component.maxdate = ''
       expect(component.isYearValid).toEqual(true)
     })
 


### PR DESCRIPTION
The same component object is used throughout all the tests. This causes
a failure for test validating that a date is valid when no range is
given, since the latent range from a previous test is still the
specified range on the component object.

This test would have just started failing on January 1, 2021; that is
when getFullYear() would have returned a value greater than 2020, the
value set as the year for the maxdate in a previous test.

Resolves: AT-5921