### PR TITLE
AT-5567: Adding pool_pre_ping: True setting

### DIFF
--- a/atat/app.py
+++ b/atat/app.py
@@ -174,6 +174,7 @@ def map_config(config):
                 "sslmode": config["default"]["PGSSLMODE"],
                 "sslrootcert": config["default"]["PGSSLROOTCERT"],
             },
+            "pool_pre_ping": True
         },
         "WTF_CSRF_ENABLED": config.getboolean("default", "WTF_CSRF_ENABLED"),
         "PERMANENT_SESSION_LIFETIME": config.getint(

--- a/atat/app.py
+++ b/atat/app.py
@@ -174,7 +174,7 @@ def map_config(config):
                 "sslmode": config["default"]["PGSSLMODE"],
                 "sslrootcert": config["default"]["PGSSLROOTCERT"],
             },
-            "pool_pre_ping": True
+            "pool_pre_ping": True,
         },
         "WTF_CSRF_ENABLED": config.getboolean("default", "WTF_CSRF_ENABLED"),
         "PERMANENT_SESSION_LIFETIME": config.getint(


### PR DESCRIPTION
Possible fix for intermittent SYSCALL EOF errors resulting in 502s for users on initial login