### PR TITLE
Fix SonarCloud Bug finding in create-saml-idp.py

### DIFF
--- a/ops/create-saml-idp.py
+++ b/ops/create-saml-idp.py
@@ -176,11 +176,11 @@ def register_self_signed_certificate(sp_object_id: str, access_token: str):
     )
 
     pem_pkcs12 = serialize_key_and_certificates(
-        name=b"saml_cert",
-        key=key,
-        cert=cert,
-        cas=None,
-        encryption_algorithm=BestAvailableEncryption(saml_signing_password.encode()),
+        b"saml_cert",
+        key,
+        cert,
+        None,
+        BestAvailableEncryption(saml_signing_password.encode()),
     )
 
     url = f"https://graph.microsoft.com/beta/servicePrincipals/{sp_object_id}"


### PR DESCRIPTION
SonarCloud reports the fact that we're passing all arguments by name as
a Blocker Bug. This is actually a false positive since we were passing
all the correct parameters in the correct order; however, since the code
is functional without the names we can go ahead and omit them.