### PR TITLE
Reduce CI vs local test environment inconsistencies

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,4 +1,7 @@
 [run]
+# Ensure that all files in this list are also excluded from
+# SonarCloud evaluation in property sonar.coverage.exclusions
+# in the file sonar-project.properties
 omit =
   atat/routes/dev.py
   atat/domain/audit_log.py

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -12,8 +12,8 @@ on:
 jobs:
   sonarcloudScan:
     name: SonarCloud Scan
-    runs-on: ubuntu-latest
-    container: "ubuntu:bionic"
+    runs-on: ubuntu-20.04
+    container: "ubuntu:focal"
     services:
       redis:
         image: redis:6
@@ -34,10 +34,6 @@ jobs:
           --health-timeout 5s
           --health-retries 5
     steps:
-      - name: Checkout Code
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
       - name: Install xmlsec and python dependencies
         run: |
           apt-get update -qqy
@@ -45,8 +41,12 @@ jobs:
           DEBIAN_FRONTEND=noninteractive apt-get install -y tzdata
           dpkg-reconfigure -f noninteractive tzdata
           apt-get install -qqy build-essential curl git
-          apt-get install -qqy sqlite3 libsqlite3-dev libffi-dev python-dev
-          apt-get install -qqy libxml2-dev libxmlsec1-dev libxmlsec1-openssl xmlsec1 
+          apt-get install -qqy sqlite3 libsqlite3-dev libffi-dev python3-dev
+          apt-get install -qqy libxml2-dev libxmlsec1-dev libxmlsec1-openssl xmlsec1 pkg-config
+      - name: Checkout Code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - name: Get pyenv
         run: |
           git clone https://github.com/pyenv/pyenv.git ~/.pyenv

--- a/script/include/run_test
+++ b/script/include/run_test
@@ -26,7 +26,6 @@ fi
 
 ## Main
 if [ "${RUN_PYTHON_TESTS}" = "true" ]; then
-
   output_divider "Lint Python files"
   run_python_lint "${PYTHON_FILES}"
   output_divider "Perform static analysis on Python files"
@@ -35,7 +34,6 @@ if [ "${RUN_PYTHON_TESTS}" = "true" ]; then
   run_python_typecheck
   output_divider "Run Python unit test suite"
   run_python_unit_tests "${PYTHON_FILES}"
-
 fi
 
 if [ "${RUN_JS_TESTS}" = "true" ]; then

--- a/script/test
+++ b/script/test
@@ -18,6 +18,11 @@ RUN_PYTHON_TESTS="true"
 # Enable Javascript testing
 RUN_JS_TESTS="true"
 
+# Ensure static asset generation works
+output_divider "Regenerate static assets"
+rm -rf ./static/assets/*
+yarn build
+
 # Check python formatting
 output_divider "Run formatting check"
 source ./script/format check

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -7,5 +7,8 @@ sonar.organization=dod-ccpo
 sonar.javascript.lcov.reportPaths=coverage/lcov.info
 sonar.python.coverage.reportPaths=coverage.xml
 sonar.exclusions=uitests/**,tests/**,coverage/**,js/test_templates/**
-sonar.coverage.exclusions=tests/**,alembic/**,js/**/tests/**,js/**/__tests__/**,ansible/**,uitests/**,ops/**,deploy/**,script/**,alembic/**,docs/**,sample-server/**,load-test/**
+# Files that are tests or are not application code are not reported on for coverage.
+# Additionally, there are some files that have been excluded from test coverage reports
+# and those same files are excluded from this list as well.
+sonar.coverage.exclusions=tests/**,alembic/**,js/**/tests/**,js/**/__tests__/**,ansible/**,uitests/**,ops/**,deploy/**,script/**,alembic/**,docs/**,sample-server/**,load-test/**,atat/routes/dev.py,atat/domain/audit_log.py,atat/models/mixins/auditable.py,atat/models/audit_event.py,atat/domain/csp/cloud/hybrid_cloud_provider.py
 sonar.cpd.exclusions=alembic/**,js/**/__tests__/**


### PR DESCRIPTION
Addresses common causes of tests failing in the CI pipeline that do not fail locally, including out-of-sync coverage exclusions and static asset generation. I've attempted to add comments to prevent similar issues from occurring in the future.

Ticket: [AT-5996](https://ccpo.atlassian.net/browse/AT-5996)