### PR TITLE
AT-5986 Remove CSRF exempts to clean up sonar issues

### DIFF
--- a/atat/app.py
+++ b/atat/app.py
@@ -56,6 +56,7 @@ def make_app(config):
     app.json_encoder = CustomJSONEncoder
     make_redis(app, config)
     csrf = CSRFProtect()
+    # These routes are exempted in order to allow SAML integration
     csrf.exempt("atat.routes.dev.login_dev")
     csrf.exempt("atat.routes.login")
     csrf.exempt("atat.routes.handle_login_response")

--- a/js/components/toggler.js
+++ b/js/components/toggler.js
@@ -15,7 +15,6 @@ export default {
   components: {
     optionsinput,
     textinput,
-    optionsinput,
     BaseForm,
     toggler: this,
   },


### PR DESCRIPTION
Remove CSRF exempts to clean up Sonar security hotspots and remove another bug with duplicate key usage in the toggler.js file

Ticket: AT-5986