### PR TITLE
Fix deployment issue with translations.yaml

### DIFF
--- a/atat/utils/localization.py
+++ b/atat/utils/localization.py
@@ -24,9 +24,10 @@ def _translations_file():
     if app:
         file_name = app.config.get("DEFAULT_TRANSLATIONS_FILE", file_name)
 
-    f = open(file_name)
-
-    return yaml.safe_load(f)
+    # Non-ASCII characters such as smart quotes may be used in the translations
+    # file and therefore it should be parsed as UTF-8
+    with open(file_name, encoding="utf-8") as translations_file:
+        return yaml.safe_load(translations_file)
 
 
 def all_keys():


### PR DESCRIPTION
This file contains non-ASCII characters such as smart quotes which will
not work with the default encoding used by `open`. Additionally, without
a context manager (using `with`) we may not be closing the file and
may leak file handles.

This supports the testing and deployments done with #2146 and AT-5711 as well as the EA deployment.