### PR TITLE
Dangerously delete less dangerously

### DIFF
--- a/ops/dangerously_delete_resource_groups.sh
+++ b/ops/dangerously_delete_resource_groups.sh
@@ -1,5 +1,18 @@
 #!/bin/bash
-for i in $(az group list --query "[? contains(name,'$1')][].{name:name}" -o tsv); do
+resource_groups="$(az group list --query "[? contains(name,'$1')][].{name:name}" -o tsv)"
+echo "==> Resource groups found"
+echo "$resource_groups"
+echo ""
+read -p "Should these all be deleted? [y/N] " -n 1 -r do_continue
+echo ""
+
+if [[ ! "$do_continue" =~ ^[Yy]$ ]]; then
+    echo "!!! Cancelling..."
+    exit 0
+fi
+
+for i in $resource_groups; do
     echo "deleting ${i}"
-    az group delete -n ${i} --yes --no-wait
+    az group delete -n "${i}" --yes --no-wait
 done
+


### PR DESCRIPTION
This script used to just take a prefix and delete everything without
prompting or validating; however, it largely seems like it is invoked in
interactive contexts, so showing the user what is going to be deleted
and asking if it is correct is probably the best way to do this. That
way we can still dangerously delete but maybe with slightly less danger.

This another PR related to the work on AT-5711 but is not tightly
integrated. These changes were made to support testing.