### PR TITLE
AT-4926 Improve accuracy of validation message for input field Application Name

### DIFF
--- a/js/lib/input_validations.js
+++ b/js/lib/input_validations.js
@@ -12,7 +12,8 @@ export default {
     mask: false,
     match: /^[A-Za-z0-9\-_,'".\s]{4,100}$$/,
     unmask: [],
-    validationError: 'Application names can be between 4-100 characters',
+    validationError:
+      'Names must be between 4 - 100 characters long and supports the following characters:  A-Z a-z 0-9 - _ , . \' " and space',
   },
   clinNumber: {
     mask: false,


### PR DESCRIPTION
Improve accuracy of validation message for input field `Application Name`

Previously the validation message only spoke to the expected length of the input.  However, the regex that validates the input field also checks content allowing only certain characters.  This change corrects the validation message to more accurately describe the characters allowed in the `Application Name` in addition to describing the accepted length.

Ticket: AT-4926