### PR TITLE
AT-5174 Improve validation flag for checkbox group

### DIFF
--- a/templates/components/multi_checkbox_input.html
+++ b/templates/components/multi_checkbox_input.html
@@ -26,19 +26,21 @@
           <div class="usa-input__title">
             {{ field.label | striptags }}
             {% if optional %}
-              <span class="usa-input-label-helper">{{ "common.optional" | translate }}</span>
+              <span class="usa-input-label-helper">
+                {{ "common.optional" | translate }}
+              </span>
             {% endif %}
             {% if tooltip %}{{ Tooltip(tooltip) }}{% endif %}
-            {% if not field.description %}
+            <span class="validation-icons" >
               {{ validation_icons }}
-            {% endif %}
+            </span>
+
           </div>
 
           {% if field.description %}
             <p class='usa-input__help'>
               {{ field.description | safe }}
             </p>
-            {{ validation_icons }}
           {% endif %}
         </legend>
 


### PR DESCRIPTION
Previously, the placement and behavior of the validation flag for the checkbox group under heading _Select DoD component(s) funding your Portfolio_ caused element displacement in the UI.

This change improves the placement and behavior of that validation flag.

Ticket: AT-5174