### PR TITLE
Remove reference to 'scriptz' repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,7 @@ This is the user-facing web application for ATAT.
 ### System Requirements
 ATAT uses the [Scripts to Rule Them All](https://github.com/github/scripts-to-rule-them-all)
 pattern for setting up and running the project. The scripts are located in the
-`script` directory and use script fragments in the
-[scriptz](https://github.com/dod-ccpo/scriptz) repository that are shared across
-ATAT repositories.
+`script` directory.
 
 General instructions follow; however, there are
 [specific instructions](/docs/WindowsSubsystemLinux.md) available for running


### PR DESCRIPTION
The reference to this repo seems to be unfinished business from this commit:
https://github.com/dod-ccpo/atat/commit/beabd2ce7295f7a736da2cb1070e88a027467e8e
The intent of that commit was to remove the scriptz submodule.  This completes
that effort and removes potentially misleading information.