### PR TITLE
Reduce GitHub Action pipeline time

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -9,6 +9,7 @@ omit =
   atat/models/audit_event.py
   atat/domain/csp/cloud/hybrid_cloud_provider.py
 branch = True
+relative_files = True
 
 [report]
 exclude_lines =

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -8,12 +8,12 @@ on:
       - "develop"
       - "release/**"
 
-
 jobs:
   sonarcloudScan:
     name: SonarCloud Scan
     runs-on: ubuntu-20.04
-    container: "ubuntu:focal"
+    env:
+      PYTHON_VERSION: "3.8.8"
     services:
       redis:
         image: redis:6
@@ -22,6 +22,8 @@ jobs:
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
+        ports:
+          - 6379:6379
       postgres:
         image: postgres:10
         env:
@@ -33,82 +35,64 @@ jobs:
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
+        ports:
+          - 5432:5432
     steps:
       - name: Install xmlsec and python dependencies
         run: |
-          apt-get update -qqy
-          echo UTC > /etc/timezone
-          DEBIAN_FRONTEND=noninteractive apt-get install -y tzdata
-          dpkg-reconfigure -f noninteractive tzdata
-          apt-get install -qqy build-essential curl git
-          apt-get install -qqy sqlite3 libsqlite3-dev libffi-dev python3-dev
-          apt-get install -qqy libxml2-dev libxmlsec1-dev libxmlsec1-openssl xmlsec1 pkg-config
+          sudo apt-get update -qqy
+          sudo apt-get install -qqy libxml2-dev libxmlsec1-dev libxmlsec1-openssl xmlsec1 pkg-config
+      - name: Install correct Python version
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
       - name: Checkout Code
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - name: Get pyenv
-        run: |
-          git clone https://github.com/pyenv/pyenv.git ~/.pyenv
-          echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc
-          echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc
-          echo -e 'if command -v pyenv 1>/dev/null 2>&1; then\n  eval "$(pyenv init -)"\nfi' >> ~/.bashrc
-        shell: bash
-      - name: Install python 3.8.8
-        run: |
-          . ~/.bashrc
-          pyenv install 3.8.8
-          pyenv global 3.8.8
-          python -V
-        shell: bash
       - name: Set Up Poetry
         run: |
-          . ~/.bashrc
-          pyenv local 3.8.8
           pip install poetry
         shell: bash
-      - name: Install yarn
-        run: |
-          curl -sL https://deb.nodesource.com/setup_10.x | bash -
-          apt-get install -qqy nodejs
-          curl -sL https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
-          echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
-          apt-get update
-          apt-get install -qqy yarn
-        shell: bash
+      - name: Cache poetry virtual environment
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-poetry-env
+        with:
+          path: ./.venv
+          key: ${{ runner.os }}-build-${{ env.PYTHON_VERSION }}-${{ env.cache-name }}-${{ hashFiles('pyproject.toml', 'poetry.lock')}}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.PYTHON_VERSION }}-${{ env.cache-name }}-
+            ${{ runner.os }}-build-${{ env.PYTHON_VERSION }}-
+      - name: Cache yarn dependencies
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-yarn-deps
+        with:
+          path: ./node_modules
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('package.json', 'yarn.lock')}}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-
       - name: Run project setup script
         run: |
-          . ~/.bashrc
-          pyenv local 3.8.8
-          apt-get install -qqy postgresql-client
+          sudo apt-get install -qqy postgresql-client
           script/setup
         shell: bash
         env:
           PGDATABASE: atat_test
-          PGHOST: postgres
+          PGHOST: localhost
           PGPORT: 5432
-          REDIS_HOST: redis:6379    
+          REDIS_HOST: localhost:6379
       - name: Run cibuild script
         run: |
-          . ~/.bashrc
-          pyenv local 3.8.8
           script/cibuild
         shell: bash
         env:
-          PGHOST: postgres
+          PGHOST: localhost
           PGPORT: 5432
-          REDIS_HOST: redis:6379
-      - name: Run sonar scan script
-        run: |
-          . ~/.bashrc
-          apt-get install -qqy unzip
-          pyenv local 3.8.8
-          script/sonar_scanner
-        shell: bash
+          REDIS_HOST: localhost:6379
+      - name: Analyze with SonarCloud
+        uses: sonarsource/sonarcloud-github-action@master
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-          PGDATABASE: atat_test
-          PGHOST: postgres
-          PGPORT: 5432
-          REDIS_HOST: redis:6379
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/script/include/run_setup
+++ b/script/include/run_setup
@@ -31,9 +31,6 @@ if [ -z "${KEEP_EXISTING_VENV+is_set}" ]; then
 fi
 
 ## Main
-# Remove any existing node modules as part of initial app setup or reset
-rm -rf ./node_modules
-
 if [ "${CREATE_VENV}" = "true" ]; then
   # Ensure poetry is installed
   if ! poetry --version >/dev/null 2>&1 ; then

--- a/script/include/test_functions.inc.sh
+++ b/script/include/test_functions.inc.sh
@@ -20,7 +20,7 @@ run_python_static_analysis() {
 }
 
 run_python_unit_tests() {
-  run_command "python -m pytest -s"
+  run_command "python -m pytest -s --cov-report=xml"
   return $?
 }
 


### PR DESCRIPTION
This relies more on the GitHub Runner rather than running in a container. This allows us to better leverage the tools cache and pre-installed packages and software. We also remove some duplicate runs of the tests by just emitting coverage reports by default. Additionally, we cache our dependencies which will help improve our run time because we've previously wasted quite a lot of time there. For Python, we only cache within a particular Python version.

Workflow run times seem to be hovering around 6m 30s to 8m.