### PR TITLE
AT-6128 Links under Application Environments are fixed for all browsers

### DIFF
--- a/styles/components/_portfolio_layout.scss
+++ b/styles/components/_portfolio_layout.scss
@@ -239,7 +239,7 @@
       font-size: $small-font-size;
 
       &.environment-list__item__members {
-        float: unset;
+        float: none;
         margin-left: -$gap;
       }
     }

--- a/templates/applications/fragments/environments.html
+++ b/templates/applications/fragments/environments.html
@@ -34,40 +34,43 @@
                 <li class="accordion-table__item">
                   <div class="accordion-table__item-content">
                     <div class="environment-list__item">
-                      {% if not env["pending"] -%}
-                        <span>
-                          <a
-                            href='{{ url_for("applications.access_environment", environment_id=env.id)}}'
-                            target='_blank'
-                            rel='noopener noreferrer'>
-                            {{ env['name'] }} {{ Icon('link', classes='icon--medium icon--primary') }}
-                          </a>
-                        </span>
-                      {% else -%}
-                        <span>
-                          {{ env['name'] }}
-                        </span>
-                        {{ Label(type="pending_creation")}}
-                      {%- endif %}
-                      {% if user_can(permissions.EDIT_ENVIRONMENT) -%}
+                      <div class="environment-list__item-line">
+                        {% if not env["pending"] -%}
+                          <span>
+                            <a
+                              href='{{ url_for("applications.access_environment", environment_id=env.id)}}'
+                              target='_blank'
+                              rel='noopener noreferrer'>
+                              {{ env['name'] }} {{ Icon('link', classes='icon--medium icon--primary') }}
+                            </a>
+                          </span>
+                        {% else -%}
+                          <span>
+                            {{ env['name'] }}
+                          </span>
+                          {{ Label(type="pending_creation")}}
+                        {%- endif %}
+                        {% if user_can(permissions.EDIT_ENVIRONMENT) -%}
+                          {{
+                          ToggleButton(
+                            open_html="common.edit"|translate,
+                            close_html="common.close"|translate,
+                            section_name="edit"
+                            )
+                          }}
+                        {%- endif %}
+                      </div>
+                      <div class="environment-list__item-line">
+                        {% set members_button = "portfolios.applications.member_count" | translate({'count': env['member_count']}) %}
                         {{
-                        ToggleButton(
-                          open_html="common.edit"|translate,
-                          close_html="common.close"|translate,
-                          section_name="edit"
+                          ToggleButton(
+                            open_html=members_button,
+                            close_html=members_button,
+                            section_name="members",
+                            classes="environment-list__item__members"
                           )
                         }}
-                      {%- endif %}
-                      <br>
-                      {% set members_button = "portfolios.applications.member_count" | translate({'count': env['member_count']}) %}
-                      {{
-                        ToggleButton(
-                          open_html=members_button,
-                          close_html=members_button,
-                          section_name="members",
-                          classes="environment-list__item__members"
-                        )
-                      }}
+                      </div>
                     </div>
                   </div>
 


### PR DESCRIPTION
On IE 11, the location of Members and Edit links are different from the other browsers.

 

This behavior was seen running locally using code as of this commit:https://github.com/dod-ccpo/atat/commit/b708a0c3df9daf9ba058030cd9dea4f8cfb38cbb

https://ccpo.atlassian.net/browse/AT-6128