### PR TITLE
fix misspelling in a enum value

### DIFF
--- a/atat/models/mixins/state_machines.py
+++ b/atat/models/mixins/state_machines.py
@@ -38,7 +38,7 @@ class AzureStages(Enum):
     INITIAL_MGMT_GROUP = "initial management group"
     INITIAL_MGMT_GROUP_VERIFICATION = "initial management group verification"
     TENANT_ADMIN_OWNERSHIP = "tenant admin ownership"
-    TENANT_PRINCIPAL_OWNERSHIP = "tenant principial ownership"
+    TENANT_PRINCIPAL_OWNERSHIP = "tenant principal ownership"
     BILLING_OWNER = "billing owner"
     TENANT_ADMIN_CREDENTIAL_RESET = "tenant admin credential reset"
     POLICIES = "policies"


### PR DESCRIPTION
This PR fixes a misspelling that was noticed in logs yesterday.

![image](https://user-images.githubusercontent.com/77642966/114211214-59426180-992e-11eb-96f1-61ca6343a1dc.png)