### PR TITLE
Refactor smoke tests to improve speed and validation points

### DIFF
--- a/uitests/framework/page_objects/__init__.py
+++ b/uitests/framework/page_objects/__init__.py
@@ -36,7 +36,8 @@ class PageObjectMethods:
     def click_application(self):
         wait = WebDriverWait(self.driver, 30)
         wait.until(
-            EC.presence_of_element_located((By.CSS_SELECTOR, self.btn_applications_css))).click()
+            EC.presence_of_element_located((By.CSS_SELECTOR, self.btn_applications_css))
+        ).click()
 
     # Validating ATAT is displayed
     def validate_atat(self):
@@ -65,7 +66,7 @@ class PageObjectMethods:
                 "Settings",
             )
         )
-    
+
     def validate_brandon(self):
         WebDriverWait(self.driver, 30).until(
             EC.text_to_be_present_in_element(

--- a/uitests/framework/page_objects/__init__.py
+++ b/uitests/framework/page_objects/__init__.py
@@ -67,3 +67,11 @@ class PageObjectMethods:
                 "Settings",
             )
         )
+    
+    def validate_brandon(self):
+        WebDriverWait(self.driver, 30).until(
+            EC.text_to_be_present_in_element(
+                (By.CSS_SELECTOR, "header > nav > div > a:nth-child(1)"),
+                "Brandon Buchannan",
+            )
+        )

--- a/uitests/framework/page_objects/__init__.py
+++ b/uitests/framework/page_objects/__init__.py
@@ -34,11 +34,9 @@ class PageObjectMethods:
         self.driver.find_element_by_css_selector(self.btn_task_orders_css).click()
 
     def click_application(self):
-        wait = WebDriverWait(self.driver, 20)
+        wait = WebDriverWait(self.driver, 30)
         wait.until(
-            EC.presence_of_element_located((By.CSS_SELECTOR, self.btn_applications_css))
-        ).click()
-        # self.driver.find_element_by_css_selector(self.btn_applications_css).click()
+            EC.presence_of_element_located((By.CSS_SELECTOR, self.btn_applications_css))).click()
 
     # Validating ATAT is displayed
     def validate_atat(self):

--- a/uitests/framework/page_objects/application_page.py
+++ b/uitests/framework/page_objects/application_page.py
@@ -1,7 +1,6 @@
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
-from . import PageObjectMethods
 import datetime
 
 time_now = datetime.datetime.now().strftime("%m%d%Y%H%M%S")
@@ -81,14 +80,12 @@ class CreateApplicationPages:
         self.driver.find_element_by_css_selector(self.btn_select_portfolio_css).click()
 
     def click_create_app(self):
-        wait = WebDriverWait(self.driver, 20)
+        wait = WebDriverWait(self.driver, 30)
         wait.until(
-            EC.presence_of_element_located((By.CSS_SELECTOR, self.btn_create_app_css))
-        ).click()
-        # self.driver.find_element_by_css_selector(self.btn_create_app_css).click()
+            EC.presence_of_element_located((By.CSS_SELECTOR, self.btn_create_app_css))).click()
 
     def click_applications(self):
-        wait = WebDriverWait(self.driver, 20)
+        wait = WebDriverWait(self.driver, 30)
         wait.until(
             EC.presence_of_element_located((By.CSS_SELECTOR, self.btn_application))
         ).click()

--- a/uitests/framework/page_objects/application_page.py
+++ b/uitests/framework/page_objects/application_page.py
@@ -280,3 +280,31 @@ class CreateApplicationPages:
                 "Save changes to revoke access, this can not be undone.",
             )
         )
+
+    def validate_name_brandon(self):
+        WebDriverWait(self.driver, 30).until(
+            EC.text_to_be_present_in_element(
+                (By.CSS_SELECTOR, "header > nav > div > a:nth-child(1)"),
+                "Brandon Buchannan",
+            )
+        )
+
+    def validate_add_members(self):
+        WebDriverWait(self.driver, 30).until(
+            EC.text_to_be_present_in_element(
+                (By.CSS_SELECTOR, "div.sticky-cta-text"), "Add Members"
+            )
+        )
+    
+    def validate_invite_sent(self):
+        WebDriverWait(self.driver, 30).until(
+            EC.text_to_be_present_in_element(
+                (By.CSS_SELECTOR, "h3.usa-alert-heading"), "invitation has been sent"
+            )
+        )
+
+    def click_create_application(self):
+        WebDriverWait(self.driver, 30).until(
+            EC.presence_of_element_located(
+                (By.CSS_SELECTOR, "a.usa-button.usa-button-primary"))).click()
+

--- a/uitests/framework/page_objects/application_page.py
+++ b/uitests/framework/page_objects/application_page.py
@@ -82,7 +82,8 @@ class CreateApplicationPages:
     def click_create_app(self):
         wait = WebDriverWait(self.driver, 30)
         wait.until(
-            EC.presence_of_element_located((By.CSS_SELECTOR, self.btn_create_app_css))).click()
+            EC.presence_of_element_located((By.CSS_SELECTOR, self.btn_create_app_css))
+        ).click()
 
     def click_applications(self):
         wait = WebDriverWait(self.driver, 30)
@@ -292,7 +293,7 @@ class CreateApplicationPages:
                 (By.CSS_SELECTOR, "div.sticky-cta-text"), "Add Members"
             )
         )
-    
+
     def validate_invite_sent(self):
         WebDriverWait(self.driver, 30).until(
             EC.text_to_be_present_in_element(
@@ -303,5 +304,6 @@ class CreateApplicationPages:
     def click_create_application(self):
         WebDriverWait(self.driver, 30).until(
             EC.presence_of_element_located(
-                (By.CSS_SELECTOR, "a.usa-button.usa-button-primary"))).click()
-
+                (By.CSS_SELECTOR, "a.usa-button.usa-button-primary")
+            )
+        ).click()

--- a/uitests/framework/page_objects/new_portfolio_page.py
+++ b/uitests/framework/page_objects/new_portfolio_page.py
@@ -82,7 +82,10 @@ class AddNewPortfolioPages:
         self.driver.find_element_by_css_selector(self.select_checkbox_css).click()
 
     def click_save_portfolio_btn(self):
-        self.driver.find_element_by_css_selector(self.save_portfolio_btn_css).click()
+        # self.driver.find_element_by_css_selector(self.save_portfolio_btn_css).click()
+        WebDriverWait(self.driver, 30).until(
+            EC.presence_of_element_located(
+                (By.CSS_SELECTOR, self.save_portfolio_btn_css))).click()
         # saveBtn = self.driver.find_element_by_css_selector(self.save_portfolio_btn_css)
         # saveBtn_text = saveBtn.text
         # if saveBtn_text == 'Save Portfolio':

--- a/uitests/framework/page_objects/new_portfolio_page.py
+++ b/uitests/framework/page_objects/new_portfolio_page.py
@@ -39,7 +39,7 @@ class AddNewPortfolioPages:
     btn_confirm_revoke = "button.action-group__action.usa-button.usa-button-primary"
     btn_resend_invite = "tr:nth-child(2) > td.toggle-menu__container > div.toggle-menu > div > a:nth-child(2)"
     btn_resend_invite_b = "td.toggle-menu__container > div > div > a:nth-child(2)"
-    btn_resend_invite_confirm = "//html/body/div/div[3]/div[2]/div/div/div[2]/div[2]/div[3]/div/div/div/div/form/div[2]/input"
+    btn_resend_invite_confirm = "input[value='Resend Invite']"
     btn_resend_invite_confirm_b = "/html/body/div/div[3]/div[2]/div/div/div[3]/div/div[1]/div[2]/div/div/div/div/form/div[2]/input"
 
     def __init__(self, driver):
@@ -85,7 +85,9 @@ class AddNewPortfolioPages:
         # self.driver.find_element_by_css_selector(self.save_portfolio_btn_css).click()
         WebDriverWait(self.driver, 30).until(
             EC.presence_of_element_located(
-                (By.CSS_SELECTOR, self.save_portfolio_btn_css))).click()
+                (By.CSS_SELECTOR, self.save_portfolio_btn_css)
+            )
+        ).click()
         # saveBtn = self.driver.find_element_by_css_selector(self.save_portfolio_btn_css)
         # saveBtn_text = saveBtn.text
         # if saveBtn_text == 'Save Portfolio':
@@ -95,7 +97,10 @@ class AddNewPortfolioPages:
         self.driver.find_element_by_css(self.cancel_portfolio_btn_css).click()
 
     def click_add_portfolio_manager(self):
-        self.driver.find_element_by_css_selector(self.btn_add_port_manager).click()
+        WebDriverWait(self.driver, 30).until(
+            EC.presence_of_element_located((By.CSS_SELECTOR, self.btn_add_port_manager))
+        ).click()
+        # self.driver.find_element_by_css_selector(self.btn_add_port_manager).click()
 
     def click_box_permissions_one(self):
         self.driver.find_element_by_css_selector(
@@ -127,7 +132,11 @@ class AddNewPortfolioPages:
         self.driver.find_element_by_css_selector(self.btn_revoke).click()
 
     def click_revoke_invite(self):
-        self.driver.find_element_by_css_selector(self.btn_revoke_invite).click()
+        WebDriverWait(self.driver, 30).until(
+            EC.presence_of_element_located((By.CSS_SELECTOR, self.btn_revoke_invite))
+        ).click()
+
+    # self.driver.find_element_by_css_selector(self.btn_revoke_invite).click()
 
     def click_revoke_invite_confirm(self):
         self.driver.find_element_by_css_selector(self.btn_revoke_invite_confirm).click()
@@ -144,7 +153,9 @@ class AddNewPortfolioPages:
     def click_resend_invite_confirm(self):
         wait = WebDriverWait(self.driver, 20)
         wait.until(
-            EC.element_to_be_clickable((By.XPATH, self.btn_resend_invite_confirm))
+            EC.element_to_be_clickable(
+                (By.CSS_SELECTOR, self.btn_resend_invite_confirm)
+            )
         ).click()
         # self.driver.find_element(By.XPATH, self.btn_resend_invite_confirm).click()
 

--- a/uitests/framework/page_objects/task_order_page.py
+++ b/uitests/framework/page_objects/task_order_page.py
@@ -1,6 +1,5 @@
 import datetime
 
-from . import PageObjectMethods
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support.wait import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
@@ -104,9 +103,10 @@ class TaskOrderPage:
         self.driver.find_element_by_css(self.lnk_dummy_file_css).click()
 
     def click_next_add_TO_number(self):
-        self.driver.find_element_by_css_selector(
-            self.btn_next_add_to_number_css
-        ).click()
+        WebDriverWait(self.driver, 30).until(
+            EC.presence_of_element_located(
+                (By.CSS_SELECTOR, self.btn_next_add_to_number_css))).click()
+        # self.driver.find_element_by_css_selector(self.btn_next_add_to_number_css).click()
 
     # Step 2 adding the task order number
     def cancel_btn_on_add_to(self):

--- a/uitests/framework/page_objects/task_order_page.py
+++ b/uitests/framework/page_objects/task_order_page.py
@@ -105,7 +105,9 @@ class TaskOrderPage:
     def click_next_add_TO_number(self):
         WebDriverWait(self.driver, 30).until(
             EC.presence_of_element_located(
-                (By.CSS_SELECTOR, self.btn_next_add_to_number_css))).click()
+                (By.CSS_SELECTOR, self.btn_next_add_to_number_css)
+            )
+        ).click()
         # self.driver.find_element_by_css_selector(self.btn_next_add_to_number_css).click()
 
     # Step 2 adding the task order number

--- a/uitests/framework/test_cases/test_create_app.py
+++ b/uitests/framework/test_cases/test_create_app.py
@@ -1,4 +1,3 @@
-import datetime
 import string
 import random
 import pytest
@@ -10,8 +9,6 @@ from selenium.webdriver.support.wait import WebDriverWait
 from uitests.framework.utilities.read_properties import ReadConfig
 from uitests.framework.page_objects.application_page import CreateApplicationPages
 from uitests.framework.page_objects import PageObjectMethods
-
-time_now = datetime.datetime.now().strftime("%m%d%Y%H%M%S")
 
 
 @pytest.mark.smoke
@@ -25,21 +22,30 @@ class TestCreateApplication:
         self.driver.maximize_window()
         self.driver.execute_script(
             'browserstack_executor: {"action": "setSessionName", '
-            '"arguments": {"name": "5. Create Application"}}')
+            '"arguments": {"name": "5. Create Application"}}'
+        )
 
         # Initializing Page Objects
         self.app = CreateApplicationPages(self.driver)
         self.cm = PageObjectMethods(self.driver)
 
+        # Generator to create unique Application name
+        self.appName = "App Name" + random_no_generator()
+
+        # Generator to create unique email address
+        self.email = random_generator() + "@gmail.com"
+
         self.cm.validate_atat()
         self.cm.validate_jedi()
         self.app.validate_name_brandon()
-        self.driver.execute_script("document.querySelector('a.usa-button.usa-button-primary').scrollIntoView()")
+        self.driver.execute_script(
+            "document.querySelector('a.usa-button.usa-button-primary').scrollIntoView()"
+        )
         self.driver.execute_script("window.scrollTo(0,document.body.scrollHeight)")
         self.app.select_portfolio()
         self.app.click_create_application()
         self.app.validate_name_desc()
-        self.app.enter_app_name(time_now + "QA App")
+        self.app.enter_app_name(self.appName)
         self.app.enter_app_description("App description goes here")
         self.app.click_next_add_environments()
         self.app.validate_app_save()
@@ -49,13 +55,14 @@ class TestCreateApplication:
         self.app.click_add_member()
         self.app.enter_first_name("Brandon")
         self.app.enter_last_name("Buchannan")
-        self.email = random_generator() + "@gmail.com"
         self.app.enter_email(self.email)
         self.app.enter_dod_id("1230456789")
         self.app.click_next_roles()
         self.app.click_edit_item_box()
         self.app.click_manage_env_box()
-        self.driver.execute_script("document.querySelector('#environment_roles-0-role-None').value='ADMIN'")
+        self.driver.execute_script(
+            "document.querySelector('#environment_roles-0-role-None').value='ADMIN'"
+        )
         self.driver.execute_script("window.scrollTo(0,document.body.scrollHeight)")
         self.app.click_save_app()
         self.app.validate_invite_sent()
@@ -79,4 +86,8 @@ class TestCreateApplication:
 
 
 def random_generator(size=15, chars=string.ascii_lowercase + string.digits):
+    return "".join(random.choice(chars) for x in range(size))
+
+
+def random_no_generator(size=17, chars=string.digits):
     return "".join(random.choice(chars) for x in range(size))

--- a/uitests/framework/test_cases/test_create_app.py
+++ b/uitests/framework/test_cases/test_create_app.py
@@ -1,5 +1,4 @@
 import datetime
-import time
 import string
 import random
 import pytest
@@ -10,6 +9,7 @@ from selenium.common.exceptions import TimeoutException
 from selenium.webdriver.support.wait import WebDriverWait
 from uitests.framework.utilities.read_properties import ReadConfig
 from uitests.framework.page_objects.application_page import CreateApplicationPages
+from uitests.framework.page_objects import PageObjectMethods
 
 time_now = datetime.datetime.now().strftime("%m%d%Y%H%M%S")
 
@@ -19,62 +19,32 @@ class TestCreateApplication:
     url2 = ReadConfig.getLoginLocalURL()
 
     def test_create_application(self, setup):
+        # Setting up driver, session/test name, maximizing window
         self.driver = setup
-        self.driver.execute_script(
-            'browserstack_executor: {"action": "setSessionName", '
-            '"arguments": {"name": "5. Create Application"}}'
-        )
         self.driver.get(self.url2)
         self.driver.maximize_window()
-        WebDriverWait(self.driver, 30).until(
-            EC.text_to_be_present_in_element(
-                (By.CSS_SELECTOR, "a.topbar__link span.topbar__link-label"), "ATAT"
-            )
-        )
-        WebDriverWait(self.driver, 30).until(
-            EC.text_to_be_present_in_element(
-                (By.CSS_SELECTOR, "header > nav > div > a:nth-child(1)"),
-                "Brandon Buchannan",
-            )
-        )
         self.driver.execute_script(
-            "document.querySelector('a.usa-button.usa-button-primary').scrollIntoView()"
-        )
-        WebDriverWait(self.driver, 30).until(
-            EC.text_to_be_present_in_element(
-                (By.CSS_SELECTOR, "div.home__content"), "JEDI Cloud Services"
-            )
-        )
+            'browserstack_executor: {"action": "setSessionName", '
+            '"arguments": {"name": "5. Create Application"}}')
+
+        # Initializing Page Objects
         self.app = CreateApplicationPages(self.driver)
+        self.cm = PageObjectMethods(self.driver)
+
+        self.cm.validate_atat()
+        self.cm.validate_jedi()
+        self.app.validate_name_brandon()
+        self.driver.execute_script("document.querySelector('a.usa-button.usa-button-primary').scrollIntoView()")
         self.driver.execute_script("window.scrollTo(0,document.body.scrollHeight)")
         self.app.select_portfolio()
-        time.sleep(30)
-        WebDriverWait(self.driver, 30).until(
-            EC.presence_of_element_located(
-                (By.CSS_SELECTOR, "a.usa-button.usa-button-primary")
-            )
-        ).click()
-        WebDriverWait(self.driver, 30).until(
-            EC.text_to_be_present_in_element(
-                (By.CSS_SELECTOR, ".sticky-cta-text"),
-                "Name and Describe New Application",
-            )
-        )
+        self.app.click_create_application()
+        self.app.validate_name_desc()
         self.app.enter_app_name(time_now + "QA App")
         self.app.enter_app_description("App description goes here")
         self.app.click_next_add_environments()
-        WebDriverWait(self.driver, 30).until(
-            EC.text_to_be_present_in_element(
-                (By.CSS_SELECTOR, "h3.usa-alert-heading"), "Application Saved"
-            )
-        )
+        self.app.validate_app_save()
         self.app.click_next_add_members()
-        time.sleep(10)
-        WebDriverWait(self.driver, 30).until(
-            EC.text_to_be_present_in_element(
-                (By.CSS_SELECTOR, "div.sticky-cta-text"), "Add Members"
-            )
-        )
+        self.app.validate_add_members()
         self.driver.execute_script("window.scrollTo(0,document.body.scrollHeight)")
         self.app.click_add_member()
         self.app.enter_first_name("Brandon")
@@ -85,16 +55,10 @@ class TestCreateApplication:
         self.app.click_next_roles()
         self.app.click_edit_item_box()
         self.app.click_manage_env_box()
-        self.driver.execute_script(
-            "document.querySelector('#environment_roles-0-role-None').value='ADMIN'"
-        )
+        self.driver.execute_script("document.querySelector('#environment_roles-0-role-None').value='ADMIN'")
         self.driver.execute_script("window.scrollTo(0,document.body.scrollHeight)")
         self.app.click_save_app()
-        WebDriverWait(self.driver, 30).until(
-            EC.text_to_be_present_in_element(
-                (By.CSS_SELECTOR, "h3.usa-alert-heading"), "invitation has been sent"
-            )
-        )
+        self.app.validate_invite_sent()
         try:
             WebDriverWait(self.driver, 30).until(
                 EC.text_to_be_present_in_element(
@@ -110,7 +74,7 @@ class TestCreateApplication:
                 'browserstack_executor: {"action": "setSessionStatus", "arguments": {"status":"failed", "reason": '
                 '"Title not matched"}}'
             )
-        print(self.driver.title)
+        print("Test: Create Application")
         self.driver.quit()
 
 

--- a/uitests/framework/test_cases/test_create_portfolio.py
+++ b/uitests/framework/test_cases/test_create_portfolio.py
@@ -1,6 +1,5 @@
 import random
 import string
-import time
 import pytest
 
 from selenium.common.exceptions import TimeoutException
@@ -9,6 +8,7 @@ from selenium.webdriver.support.wait import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
 from uitests.framework.utilities.read_properties import ReadConfig
 from uitests.framework.page_objects.new_portfolio_page import AddNewPortfolioPages
+from uitests.framework.page_objects import PageObjectMethods
 
 
 @pytest.mark.smoke
@@ -16,24 +16,29 @@ class TestCreatePortfolio:
     url2 = ReadConfig.getLoginLocalURL()
 
     def test_create_portfolio(self, setup):
+        # Setting up driver, session/test name, maximizing window
         self.driver = setup
+        self.driver.get(self.url2)
+        self.driver.maximize_window()
+        self.driver.execute_script("window.scrollTo(0,document.body.scrollHeight)")
         self.driver.execute_script(
             'browserstack_executor: {"action": "setSessionName", '
             '"arguments": {"name": "3. Create Portfolio"}}'
         )
-        self.driver.get(self.url2)
-        self.driver.maximize_window()
-        self.driver.execute_script("window.scrollTo(0,document.body.scrollHeight)")
-        assert "ATAT" in self.driver.page_source
+        # Initializing Page Objects
         self.port = AddNewPortfolioPages(self.driver)
+        self.cm = PageObjectMethods(self.driver)
+
+        # Generating random portfolio name
+        self.pName = "Test Portfolio" + random_generator()
+
+        self.cm.validate_atat()
+        self.cm.validate_jedi()
         self.port.click_new_portfolio()
         self.port.validate_new_portfolio()
         self.port.validate_name_desc()
-        self.pName = "Test Portfolio" + random_generator()
         self.port.enter_portfolio_name(self.pName)
-        self.port.enter_portfolio_description(
-            "Entering the description to verify the text"
-        )
+        self.port.enter_portfolio_description("Entering the description to verify the text")
         self.driver.execute_script("window.scrollTo(0,document.body.scrollHeight)")
         self.port.select_checkbox()
         self.port.click_save_portfolio_btn()
@@ -53,7 +58,7 @@ class TestCreatePortfolio:
                 'browserstack_executor: {"action": "setSessionStatus", "arguments": {"status":"failed", "reason": '
                 '"Text is NOT Matched"}}'
             )
-        print("Task Orders")
+        print("Test: Create Portfolio")
         self.driver.quit()
 
 

--- a/uitests/framework/test_cases/test_create_portfolio.py
+++ b/uitests/framework/test_cases/test_create_portfolio.py
@@ -38,7 +38,9 @@ class TestCreatePortfolio:
         self.port.validate_new_portfolio()
         self.port.validate_name_desc()
         self.port.enter_portfolio_name(self.pName)
-        self.port.enter_portfolio_description("Entering the description to verify the text")
+        self.port.enter_portfolio_description(
+            "Entering the description to verify the text"
+        )
         self.driver.execute_script("window.scrollTo(0,document.body.scrollHeight)")
         self.port.select_checkbox()
         self.port.click_save_portfolio_btn()

--- a/uitests/framework/test_cases/test_create_to.py
+++ b/uitests/framework/test_cases/test_create_to.py
@@ -1,4 +1,3 @@
-import datetime
 import os
 import pytest
 import random
@@ -11,7 +10,6 @@ from uitests.framework.page_objects.new_portfolio_page import AddNewPortfolioPag
 from uitests.framework.page_objects import PageObjectMethods
 
 current_dir_path = "./uitests/framework/resources/test.pdf"
-tnumber = datetime.datetime.now().strftime("%m%d%Y%H%M%S%f")[:-3]
 
 
 @pytest.mark.smoke
@@ -34,16 +32,20 @@ class TestCreateTaskOrder:
         self.to = TaskOrderPage(self.driver)
         self.cm = PageObjectMethods(self.driver)
 
-        # Generator to create random Test Portfolio name
+        # Generator to create unique Portfolio name
         self.pName = "Test Portfolio" + random_generator()
+
+        # Generator to create unique Application name
+        self.appName = "App Name" + random_no_generator()
+
+        # Generator to create unique Task Order number
+        self.toNumber = random_no_generator()
 
         self.cm.validate_atat()
         self.cm.validate_jedi()
         self.port.click_new_portfolio()
         self.port.validate_new_portfolio()
         self.port.validate_name_desc()
-
-        # Entering portfolio name from generato
         self.port.enter_portfolio_name(self.pName)
         self.port.enter_portfolio_description(
             "Entering the description to verify the text"
@@ -67,7 +69,7 @@ class TestCreateTaskOrder:
         file_input = self.driver.find_element_by_id("pdf")
         file_input.send_keys(absolute_file_path)
         self.to.click_next_add_TO_number()
-        self.to.enter_TO_number(tnumber)
+        self.to.enter_TO_number(self.toNumber)
         self.driver.execute_script("window.scrollTo(0,document.body.scrollHeight)")
         self.to.click_next_add_clin_number()
         self.to.enter_clin_number("0001")
@@ -104,4 +106,8 @@ class TestCreateTaskOrder:
 
 
 def random_generator(size=15, chars=string.ascii_lowercase + string.digits):
+    return "".join(random.choice(chars) for x in range(size))
+
+
+def random_no_generator(size=17, chars=string.digits):
     return "".join(random.choice(chars) for x in range(size))

--- a/uitests/framework/test_cases/test_create_to.py
+++ b/uitests/framework/test_cases/test_create_to.py
@@ -1,6 +1,5 @@
 import datetime
 import os
-import time
 import pytest
 import random
 import string
@@ -9,6 +8,7 @@ from selenium.common.exceptions import TimeoutException
 from uitests.framework.page_objects.task_order_page import TaskOrderPage, time_run
 from uitests.framework.utilities.read_properties import ReadConfig
 from uitests.framework.page_objects.new_portfolio_page import AddNewPortfolioPages
+from uitests.framework.page_objects import PageObjectMethods
 
 current_dir_path = "./uitests/framework/resources/test.pdf"
 tnumber = datetime.datetime.now().strftime("%m%d%Y%H%M%S%f")[:-3]
@@ -19,20 +19,31 @@ class TestCreateTaskOrder:
     url2 = ReadConfig.getLoginLocalURL()
 
     def test_create_task_order(self, setup):
+        # Setting up driver, session/test name, maximizing window
         self.driver = setup
+        self.driver.get(self.url2)
+        self.driver.maximize_window()
+        self.driver.execute_script("window.scrollTo(0,document.body.scrollHeight)")
         self.driver.execute_script(
             'browserstack_executor: {"action": "setSessionName", '
             '"arguments": {"name": "4. Create Active Task Order"}}'
         )
-        self.driver.get(self.url2)
-        self.driver.maximize_window()
-        self.driver.execute_script("window.scrollTo(0,document.body.scrollHeight)")
-        assert "ATAT" in self.driver.page_source
+
+        # Initializing Page Objects
         self.port = AddNewPortfolioPages(self.driver)
+        self.to = TaskOrderPage(self.driver)
+        self.cm = PageObjectMethods(self.driver)
+
+        # Generator to create random Test Portfolio name
+        self.pName = "Test Portfolio" + random_generator()
+
+        self.cm.validate_atat()
+        self.cm.validate_jedi()
         self.port.click_new_portfolio()
         self.port.validate_new_portfolio()
         self.port.validate_name_desc()
-        self.pName = "Test Portfolio" + random_generator()
+
+        # Entering portfolio name from generato
         self.port.enter_portfolio_name(self.pName)
         self.port.enter_portfolio_description(
             "Entering the description to verify the text"
@@ -42,8 +53,6 @@ class TestCreateTaskOrder:
         self.port.click_save_portfolio_btn()
         self.msg = self.driver.find_element_by_tag_name("h1").text
         assert self.pName == self.msg
-        print(self.msg)
-        self.to = TaskOrderPage(self.driver)
         self.to.click_task_order()
         self.to.validate_add_to()
         self.to.click_add_new_to()
@@ -58,7 +67,6 @@ class TestCreateTaskOrder:
         file_input = self.driver.find_element_by_id("pdf")
         file_input.send_keys(absolute_file_path)
         self.to.click_next_add_TO_number()
-        time.sleep(10)
         self.to.enter_TO_number(tnumber)
         self.driver.execute_script("window.scrollTo(0,document.body.scrollHeight)")
         self.to.click_next_add_clin_number()
@@ -72,10 +80,8 @@ class TestCreateTaskOrder:
         self.to.add_end_day("12")
         self.to.add_end_year("2021")
         self.to.click_next_review_TO()
-        time.sleep(5)
         self.to.click_confirm()
         self.driver.execute_script("window.scrollTo(0,document.body.scrollHeight)")
-        time.sleep(10)
         self.to.click_checkbox_one()
         self.to.click_check_box_two()
         self.to.click_submit_TO()
@@ -93,7 +99,7 @@ class TestCreateTaskOrder:
                 'browserstack_executor: {"action": "setSessionStatus", "arguments": {"status":"passed", "reason": '
                 '"Text value matched"}}'
             )
-        print(self.driver.title)
+        print("Test: Create Active Task Order")
         self.driver.quit()
 
 

--- a/uitests/framework/test_cases/test_login.py
+++ b/uitests/framework/test_cases/test_login.py
@@ -10,31 +10,27 @@ from uitests.framework.utilities.read_properties import ReadConfig
 
 
 @pytest.mark.smoke
-class TestLogin:
+class Test_Login:
     url2 = ReadConfig.getLoginLocalURL()
 
     def test_user_login(self, setup):
+        # Setting up driver, session/test name, maximizing window
         self.driver = setup
+        self.driver.get(self.url2)
+        self.driver.maximize_window()
         self.driver.execute_script(
             'browserstack_executor: {"action": "setSessionName", '
             '"arguments": {"name": "1. Verification of User Login"}}'
         )
-        self.driver.get(self.url2)
-        self.driver.maximize_window()
-        WebDriverWait(self.driver, 30).until(
-            EC.text_to_be_present_in_element(
-                (By.CSS_SELECTOR, "a.topbar__link span.topbar__link-label"), "ATAT"
-            )
-        )
+
+        # Initializing Page Objects
         self.login = Login(self.driver)
-        self.login.userName()
         self.cm = PageObjectMethods(self.driver)
+
+        self.cm.validate_atat()
+        self.cm.validate_jedi()
+        self.login.userName()
         self.cm.click_Home()
-        WebDriverWait(self.driver, 30).until(
-            EC.text_to_be_present_in_element(
-                (By.CSS_SELECTOR, "div.home__content"), "JEDI Cloud Services"
-            )
-        )
         self.login.clickLogout()
         try:
             WebDriverWait(self.driver, 5).until(
@@ -51,5 +47,5 @@ class TestLogin:
                 'browserstack_executor: {"action": "setSessionStatus", "arguments": {"status":"failed", "reason": '
                 '"Logout Not Successful"}}'
             )
-        print(self.driver.title)
+        print("Test: Verification of User Login")
         self.driver.quit()

--- a/uitests/framework/test_cases/test_reports_basic.py
+++ b/uitests/framework/test_cases/test_reports_basic.py
@@ -1,4 +1,3 @@
-import datetime
 import os
 import random
 import string
@@ -12,7 +11,6 @@ from uitests.framework.utilities.read_properties import ReadConfig
 from uitests.framework.page_objects import PageObjectMethods
 
 current_dir_path = "./uitests/framework/resources/test.pdf"
-tnumber = datetime.datetime.now().strftime("%m%d%Y%H%M%S%f")[:-3]
 
 
 @pytest.mark.smoke
@@ -35,12 +33,17 @@ class TestReportsBasic:
         self.to = TaskOrderPage(self.driver)
         self.rep = ReportsPages(self.driver)
 
+        # Generator to create unique Test Portfolio name
+        self.pName = "Test Portfolio" + random_generator()
+
+        # Generator to create task order number
+        self.toNumber = random_no_generator()
+
         self.cm.validate_atat()
         self.cm.validate_jedi()
         self.port.click_new_portfolio()
         self.port.validate_new_portfolio()
         self.port.validate_name_desc()
-        self.pName = "Test Portfolio" + random_generator()
         self.port.enter_portfolio_name(self.pName)
         self.port.enter_portfolio_description(
             "Entering the description to verify the text"
@@ -65,7 +68,7 @@ class TestReportsBasic:
         file_input = self.driver.find_element_by_id("pdf")
         file_input.send_keys(absolute_file_path)
         self.to.click_next_add_TO_number()
-        self.to.enter_TO_number(tnumber)
+        self.to.enter_TO_number(self.toNumber)
         self.driver.execute_script("window.scrollTo(0,document.body.scrollHeight)")
         self.to.click_next_add_clin_number()
         self.to.enter_clin_number("0001")
@@ -111,4 +114,8 @@ class TestReportsBasic:
 
 
 def random_generator(size=15, chars=string.ascii_lowercase + string.digits):
+    return "".join(random.choice(chars) for x in range(size))
+
+
+def random_no_generator(size=17, chars=string.digits):
     return "".join(random.choice(chars) for x in range(size))

--- a/uitests/framework/test_cases/test_reports_basic.py
+++ b/uitests/framework/test_cases/test_reports_basic.py
@@ -2,7 +2,6 @@ import datetime
 import os
 import random
 import string
-import time
 import pytest
 
 from selenium.common.exceptions import TimeoutException
@@ -10,6 +9,7 @@ from uitests.framework.page_objects.new_portfolio_page import AddNewPortfolioPag
 from uitests.framework.page_objects.reports_page import ReportsPages
 from uitests.framework.page_objects.task_order_page import TaskOrderPage, time_run
 from uitests.framework.utilities.read_properties import ReadConfig
+from uitests.framework.page_objects import PageObjectMethods
 
 current_dir_path = "./uitests/framework/resources/test.pdf"
 tnumber = datetime.datetime.now().strftime("%m%d%Y%H%M%S%f")[:-3]
@@ -21,32 +21,35 @@ class TestReportsBasic:
 
     def test_reports_basic(self, setup):
         self.driver = setup
+        self.driver.get(self.url2)
+        self.driver.maximize_window()
+        self.driver.execute_script("window.scrollTo(0,document.body.scrollHeight)")
         self.driver.execute_script(
             'browserstack_executor: {"action": "setSessionName", '
             '"arguments": {"name": "6. Verifying Reports - Active TO"}}'
         )
-        self.driver.get(self.url2)
-        self.driver.maximize_window()
-        self.driver.execute_script("window.scrollTo(0,document.body.scrollHeight)")
-        assert "ATAT" in self.driver.page_source
+
+        # Initializing Page Objects
+        self.cm = PageObjectMethods(self.driver)
         self.port = AddNewPortfolioPages(self.driver)
+        self.to = TaskOrderPage(self.driver)
+        self.rep = ReportsPages(self.driver)
+
+        self.cm.validate_atat()
+        self.cm.validate_jedi()
         self.port.click_new_portfolio()
         self.port.validate_new_portfolio()
         self.port.validate_name_desc()
         self.pName = "Test Portfolio" + random_generator()
-        self.rep = ReportsPages(self.driver)
         self.port.enter_portfolio_name(self.pName)
         self.port.enter_portfolio_description(
             "Entering the description to verify the text"
         )
         self.driver.execute_script("window.scrollTo(0,document.body.scrollHeight)")
         self.port.select_checkbox()
-        time.sleep(5)
         self.port.click_save_portfolio_btn()
         self.msg = self.driver.find_element_by_tag_name("h1").text
         assert self.pName == self.msg
-        print(self.msg)
-        self.to = TaskOrderPage(self.driver)
         self.to.click_task_order()
         self.to.validate_add_to()
         self.driver.execute_script("window.scrollTo(0,document.body.scrollHeight)")
@@ -62,9 +65,6 @@ class TestReportsBasic:
         file_input = self.driver.find_element_by_id("pdf")
         file_input.send_keys(absolute_file_path)
         self.to.click_next_add_TO_number()
-        time.sleep(10)
-        # calling from wrong PO's file
-        # self.rep.enter_TO_number(tnumber)
         self.to.enter_TO_number(tnumber)
         self.driver.execute_script("window.scrollTo(0,document.body.scrollHeight)")
         self.to.click_next_add_clin_number()
@@ -78,10 +78,8 @@ class TestReportsBasic:
         self.to.add_end_day("12")
         self.to.add_end_year("2021")
         self.to.click_next_review_TO()
-        time.sleep(5)
         self.to.click_confirm()
         self.driver.execute_script("window.scrollTo(0,document.body.scrollHeight)")
-        time.sleep(10)
         self.to.click_checkbox_one()
         self.to.click_check_box_two()
         self.to.click_submit_TO()
@@ -98,7 +96,6 @@ class TestReportsBasic:
             self.rep.active_to_text()
             tno = str(time_run)
             self.rep.active_task_order_number(tno)
-            print(tno)
         except TimeoutException:
             self.driver.execute_script(
                 'browserstack_executor: {"action": "setSessionStatus", "arguments": {"status":"failed", "reason": '
@@ -109,7 +106,7 @@ class TestReportsBasic:
                 'browserstack_executor: {"action": "setSessionStatus", "arguments": {"status":"passed", "reason": '
                 '"Active TaskOrder is matched"}}'
             )
-        print(self.driver.title)
+        print("Test: Verifying Reports - Active TO")
         self.driver.quit()
 
 

--- a/uitests/framework/test_cases/test_revoke_env.py
+++ b/uitests/framework/test_cases/test_revoke_env.py
@@ -1,4 +1,3 @@
-import datetime
 import random
 import string
 
@@ -11,8 +10,6 @@ from uitests.framework.page_objects.application_page import CreateApplicationPag
 from uitests.framework.page_objects import PageObjectMethods
 from uitests.framework.page_objects.new_portfolio_page import AddNewPortfolioPages
 from uitests.framework.utilities.read_properties import ReadConfig
-
-time_now = datetime.datetime.now().strftime("%m%d%Y%H%M%S%f")[:-3]
 
 
 @pytest.mark.regression
@@ -35,8 +32,14 @@ class Test_010_revoke_environment:
         self.port = AddNewPortfolioPages(self.driver)
         self.app = CreateApplicationPages(self.driver)
 
-        # Generator to create random Test Portfolio name
+        # Generator to create unique Portfolio name
         self.pName = "Test Portfolio" + random_generator()
+
+        # Generator to create unique Application name
+        self.appName = "App Name" + random_no_generator()
+
+        # Generator to create unique email address
+        self.email = random_generator() + "@gmail.com"
 
         self.cm.validate_atat()
         self.cm.validate_jedi()
@@ -53,10 +56,7 @@ class Test_010_revoke_environment:
         self.cm.click_application()
         self.app.click_create_app()
         self.app.validate_name_desc()
-
-        # Entering the application name using time stamp
-        self.app.enter_app_name(time_now)
-
+        self.app.enter_app_name(self.appName)
         self.app.enter_app_description("App description goes here")
         self.app.click_next_add_environments()
         self.app.validate_app_save()
@@ -65,7 +65,6 @@ class Test_010_revoke_environment:
         self.app.click_add_team_member()
         self.app.enter_first_name("Brandon")
         self.app.enter_last_name("Buchannan")
-        self.email = random_generator() + "@gmail.com"
         self.app.enter_email(self.email)
         self.app.enter_dod_id("1230456789")
         self.app.click_next_roles()
@@ -117,4 +116,8 @@ class Test_010_revoke_environment:
 
 
 def random_generator(size=15, chars=string.ascii_lowercase + string.digits):
+    return "".join(random.choice(chars) for x in range(size))
+
+
+def random_no_generator(size=17, chars=string.digits):
     return "".join(random.choice(chars) for x in range(size))

--- a/uitests/framework/test_cases/test_settings.py
+++ b/uitests/framework/test_cases/test_settings.py
@@ -1,4 +1,3 @@
-import time
 import pytest
 
 from selenium.common.exceptions import TimeoutException
@@ -6,6 +5,8 @@ from selenium.webdriver.support.wait import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
 from uitests.framework.utilities.read_properties import ReadConfig
 from uitests.framework.page_objects.settings_page import SettingsPages
+from uitests.framework.page_objects import PageObjectMethods
+from uitests.framework.page_objects.new_portfolio_page import AddNewPortfolioPages
 
 
 @pytest.mark.smoke
@@ -13,22 +14,27 @@ class TestSettings:
     url2 = ReadConfig.getLoginLocalURL()
 
     def test_settings(self, setup):
+        # Setting up driver, session/test name, maximizing window
         self.driver = setup
+        self.driver.get(self.url2)
+        self.driver.maximize_window()
+        self.driver.execute_script("window.scrollTo(0,document.body.scrollHeight)")
         self.driver.execute_script(
             'browserstack_executor: {"action": "setSessionName", '
             '"arguments": {"name": "2. Validating Settings"}}'
         )
-        self.driver.get(self.url2)
-        self.driver.maximize_window()
-        self.driver.execute_script("window.scrollTo(0,document.body.scrollHeight)")
-        time.sleep(20)
-        assert "ATAT" in self.driver.page_source
+
+        # Initializing Page Objects
+        self.cm = PageObjectMethods(self.driver)
         self.set = SettingsPages(self.driver)
+        self.port = AddNewPortfolioPages(self.driver)
+
+        self.cm.validate_atat()
+        self.cm.validate_jedi()
         self.set.select_portfolio()
-        time.sleep(20)
+        self.cm.validate_brandon()
         self.set.click_settings()
-        time.sleep(20)
-        assert "Portfolio name and component" in self.driver.page_source
+        self.port.validating_name_comp()
         try:
             WebDriverWait(self.driver, 5).until(EC.title_contains("JEDI Cloud"))
             self.driver.execute_script(
@@ -40,5 +46,5 @@ class TestSettings:
                 'browserstack_executor: {"action": "setSessionStatus", "arguments": {"status":"failed", "reason": '
                 '"Title not matched"}}'
             )
-        print(self.driver.title)
+        print("Test: Validating Settings")
         self.driver.quit()


### PR DESCRIPTION
The issue with IE11 seems to have been resolved.  The initial smoke tests had time.sleep written in the code which is now removed.  The page assertions were scanning the page for text and have been replaced with validation that points to specific areas/elements on the page to ensure not only the text is displayed but displaying in the right location. 
Ticket: AT-6159