### PR TITLE
AT-5596 Remove Secondary "Log in" button from sign-in page

### DIFF
--- a/templates/navigation/topbar.html
+++ b/templates/navigation/topbar.html
@@ -27,11 +27,6 @@
         <span class="topbar__link-label">Logout</span>
         {{ Icon('logout', classes='topbar__link-icon') }}
       </a>
-      {% else %}
-      <a href="{{ url_for('atat.home') }}" class="topbar__link" title='Login'>
-        <span class="topbar__link-label">{{ "base_public.login" | translate }}</span>
-        {{ Icon('avatar', classes='topbar__link-icon') }}
-      </a>
       {% endif %}
     </div>
   </nav>

--- a/templates/navigation/topbar.html
+++ b/templates/navigation/topbar.html
@@ -21,7 +21,6 @@
         <span class="topbar__link-label">Support</span>
       </a>
       {% endif %}
-
       <a href="{{ url_for('atat.logout') }}" class="topbar__link"
         title='{{ "navigation.topbar.logout_link_title" | translate }}' v-on:click="logout">
         <span class="topbar__link-label">Logout</span>


### PR DESCRIPTION
Remove "login" button from the top right-hand corner of the home page.

Ticket: AT-5596