### PR TITLE
AT-5984 Fix 'Learn More' href in members form

### DIFF
--- a/templates/applications/fragments/member_form_fields.html
+++ b/templates/applications/fragments/member_form_fields.html
@@ -86,7 +86,7 @@
 
 {% macro PermsFields(form, new=False, member_role_id=None) %}
   <h2>{{ "portfolios.applications.members.form.app_perms.title" | translate }}</h2>
-  <p class='usa-input__help subtitle'>{{ "portfolios.applications.members.form.app_perms.description" | translate | safe}}</p>
+  <p class='usa-input__help subtitle'>{{ "portfolios.applications.members.form.app_perms.description" | translate({"learn_more_url": "https://docs.microsoft.com/en-us/azure/role-based-access-control/built-in-roles"}) | safe}}</p>
   <div class="application-perms">
     {% if new %}
       {% set team_mgmt = form.perms_team_mgmt.name %}
@@ -106,7 +106,7 @@
       {% if not new -%}
         {{ "portfolios.applications.members.form.env_access.edit_description" | translate }}
       {%- endif %}
-      {{ "portfolios.applications.members.form.env_access.description" | translate | safe }}
+      {{ "portfolios.applications.members.form.env_access.description" | translate({"learn_more_url": "https://docs.microsoft.com/en-us/azure/role-based-access-control/built-in-roles"}) | safe }}
     </p>
     <hr>
     {% for environment_data in form.environment_roles %}

--- a/translations.yaml
+++ b/translations.yaml
@@ -456,13 +456,13 @@ portfolios:
           title: Environment Roles
           table_header: Environment Access
           edit_description: Add or revoke Environment access.
-          description: Additional role controls are available in the CSP console. <a href="#"> Learn More </a>
+          description: Additional role controls are available in the CSP console. <a href="{learn_more_url}" target="_blank"> Learn More </a>
           revoke_warning: Save changes to revoke access, <strong>this can not be undone.</strong>
           suspended: Suspended access cannot be modified.
         next_button: "Next: Roles and Permissions"
         app_perms:
           title: Application Permissions
-          description: Application permissions allow users to provision and modify applications and teams. <a href="#"> Learn More </a>
+          description: Application permissions allow users to provision and modify applications and teams. <a href="{learn_more_url}" target="_blank"> Learn More </a>
         edit_access_header: "Manage {user}'s Access"
         add_member: Add Member
       menu:


### PR DESCRIPTION
Updated `hrefs` for the _Learn More_ links found in the members form under Environment Roles heading.

Ticket: AT-5984