### PR TITLE
Improve Task Order PDF uniqueness guarantees

### DIFF
--- a/atat/domain/csp/files.py
+++ b/atat/domain/csp/files.py
@@ -67,9 +67,6 @@ class AzureFileService(FileService):
             expiry=pendulum.now(tz="UTC").add(self.timeout),
             protocol="https",
         )
-        # TODO: remove object name from this tuple -- generate in js
-        # We generate a UUID here only for it to be passed through to the frontend where it's used as the name of the
-        # blob that's uploaded. We should just generate the object name there.
         return {"token": sas_token}, self.generate_object_name()
 
     def generate_download_link(self, object_name, filename):

--- a/atat/domain/csp/files.py
+++ b/atat/domain/csp/files.py
@@ -1,26 +1,37 @@
-from typing import Tuple
+from typing import Dict, Tuple
 from uuid import uuid4
 
 import pendulum
 
 
 class FileService:
-    def generate_token(self):
+    def service_name(self) -> str:  # pragma: no cover
         raise NotImplementedError()
 
-    def generate_download_link(self, object_name, filename) -> Tuple[dict, str]:
+    def generate_token(self):  # pragma: no cover
+        raise NotImplementedError()
+
+    def generate_download_link(
+        self, object_name, filename
+    ) -> Tuple[dict, str]:  # pragma: no cover
         raise NotImplementedError()
 
     def generate_object_name(self) -> str:
         return str(uuid4())
 
-    def download_task_order(self, object_name):
+    def download_task_order(self, object_name):  # pragma: no cover
         raise NotImplementedError()
+
+    def client_upload_config(self) -> Dict[str, str]:
+        return {}
 
 
 class MockFileService(FileService):
     def __init__(self, config):
         self.config = config
+
+    def service_name(self) -> str:
+        return "mock"
 
     def get_token(self):
         return {}, self.generate_object_name()
@@ -49,6 +60,9 @@ class AzureFileService(FileService):
         import azure.storage.blob
 
         self.blob = azure.storage.blob
+
+    def service_name(self) -> str:
+        return "azure"
 
     def get_token(self):
         """
@@ -127,3 +141,9 @@ class AzureFileService(FileService):
             )
             valid = not blob_client.exists()
         return blob_name
+
+    def client_upload_config(self) -> Dict[str, str]:
+        return {
+            "azureAccountName": self.account_name,
+            "azureContainerName": self.container_name,
+        }

--- a/atat/models/task_order.py
+++ b/atat/models/task_order.py
@@ -36,7 +36,7 @@ class TaskOrder(Base, mixins.TimestampsMixin):
     portfolio_id = Column(ForeignKey("portfolios.id"), nullable=False)
     portfolio = relationship("Portfolio")
 
-    pdf_attachment_id = Column(ForeignKey("attachments.id"))
+    pdf_attachment_id = Column(ForeignKey("attachments.id"), unique=True)
     _pdf = relationship("Attachment", foreign_keys=[pdf_attachment_id])
     pdf_last_sent_at = Column(DateTime)
     number = Column(String, unique=True,)  # Task Order Number

--- a/atat/routes/task_orders/new.py
+++ b/atat/routes/task_orders/new.py
@@ -99,33 +99,15 @@ def update_and_render_next(
         )
 
 
-def upload_config(csp, config):
-    if csp == "azure" or csp == "hybrid":
-        return {
-            "azureAccountName": config["AZURE_STORAGE_ACCOUNT_NAME"],
-            "azureContainerName": config["AZURE_TO_BUCKET_NAME"],
-        }
-    else:
-        return {}
-
-
-def upload_cloud_provider(csp):
-    if csp == "hybrid":
-        return "azure"
-    else:
-        return csp
-
-
 @task_orders_bp.route("/task_orders/<portfolio_id>/upload_token")
 @user_can(Permissions.CREATE_TASK_ORDER, message="edit task order form")
 def upload_token(portfolio_id):
-    (token, object_name) = app.csp.files.get_token()
-    csp = app.config["CSP"]
+    token, object_name = app.csp.files.get_token()
     render_args = {
-        "cloudProvider": upload_cloud_provider(csp),
+        "cloudProvider": app.csp.files.service_name(),
         "token": token,
         "objectName": object_name,
-        "config": upload_config(csp, app.config),
+        "config": app.csp.files.client_upload_config(),
     }
 
     return jsonify(render_args)

--- a/tests/domain/cloud/test_azure_file_service.py
+++ b/tests/domain/cloud/test_azure_file_service.py
@@ -10,6 +10,10 @@ def file_service(app):
     return file_service
 
 
+def test_service_name(file_service):
+    assert file_service.service_name() == "azure"
+
+
 def test_get_token(file_service, mocker):
     mocker.patch.object(
         azure.storage.blob, "generate_container_sas", return_value="container_sas_token"
@@ -56,6 +60,14 @@ def test_generate_download_link(file_service, mocker, app):
         download_link
         == f"https://{file_service.account_name}.blob.core.windows.net/{file_service.container_name}/{object_name}?blob_sas_token"
     )
+
+
+def test_client_upload_config(file_service):
+    client_config = file_service.client_upload_config()
+    assert "azureAccountName" in client_config
+    assert "azureContainerName" in client_config
+    assert client_config["azureAccountName"] == file_service.account_name
+    assert client_config["azureContainerName"] == file_service.container_name
 
 
 @pytest.fixture

--- a/tests/domain/cloud/test_azure_file_service.py
+++ b/tests/domain/cloud/test_azure_file_service.py
@@ -14,8 +14,36 @@ def test_get_token(file_service, mocker):
     mocker.patch.object(
         azure.storage.blob, "generate_container_sas", return_value="container_sas_token"
     )
+    mocker.patch.object(file_service.blob, "BlobClient")
+    file_service.blob.BlobClient.return_value.exists.return_value = False
     token_dict, _ = file_service.get_token()
     assert token_dict["token"] == "container_sas_token"
+
+
+def test_generate_object_name_no_retries_if_not_exist(file_service, mocker):
+    mocker.patch.object(
+        azure.storage.blob, "generate_container_sas", return_value="container_sas_token"
+    )
+    mocker.patch.object(file_service.blob, "BlobClient")
+    file_service.blob.BlobClient.return_value.exists.return_value = False
+    assert file_service.generate_object_name()
+    file_service.blob.BlobClient.return_value.exists.assert_called_once()
+
+
+def test_generate_object_name_does_retry_if_exists(file_service, mocker):
+    mocker.patch.object(
+        azure.storage.blob, "generate_container_sas", return_value="container_sas_token"
+    )
+    mocker.patch.object(file_service.blob, "BlobClient")
+    file_service.blob.BlobClient.return_value.exists.side_effect = [
+        True,
+        True,
+        True,
+        False,
+        True,
+    ]
+    assert file_service.generate_object_name()
+    assert len(file_service.blob.BlobClient.return_value.exists.call_args_list) == 4
 
 
 def test_generate_download_link(file_service, mocker, app):

--- a/tests/routes/task_orders/test_new.py
+++ b/tests/routes/task_orders/test_new.py
@@ -534,7 +534,7 @@ def test_upload_token(app, client, user_session, portfolio):
     )
     assert response.status_code == 200
     token_resp = response.get_json()
-    assert token_resp["cloudProvider"] == app.config["CSP"]
+    assert token_resp["cloudProvider"] == app.csp.files.service_name()
     assert isinstance(token_resp["token"], dict)
     assert isinstance(token_resp["objectName"], str)
     assert isinstance(token_resp["config"], dict)


### PR DESCRIPTION
Adds two distinct mechanisms to improve the uniqueness of Task Order PDFs:
1. Performs basic validation that the object name is not already in use
2. Constrains PDF attachment IDs to be UNIQUE

This will ensure that it is at least impossible to overwrite an object that has already existed in CSP storage (but does not prevent concurrent conflicting writes) and that two task orders cannot share the same PDF attachment object. If the same Task Order PDF is for some reason valid twice, then it will need to be uploaded twice with different names/IDs (which the UI would require anyway).

This also implements a quick fix for a bug impacting file uploads in `ea-hybrid` environments.

Ticket: AT-5062