### PR TITLE
Re-generate static assets on script/update

### DIFF
--- a/script/update
+++ b/script/update
@@ -12,3 +12,6 @@ MIGRATE_DB="true"
 
 # Run the shared update script
 source ./script/include/run_update
+
+# Re-generate static assets
+yarn build


### PR DESCRIPTION
In some scenarios, it is possible that an update to JavaScript
dependencies also requires that the static assets are re-generated;
however, this is currently nothing that exists in our scripting to
enforce that. Regeneration already takes place in `script/setup` and in
`script/test` so there is precedent for this in the scripting.

This does not require any changes to our deployment scripts or the CI
pipeline scripts since both of those already start with a fresh
environment without static assets and have to generate them regardless
(usually as part of `script/setup`). This is a change that purely brings
the local environment in line with our other environments.