### PR TITLE
Cleanup use of hard coded strings in favor of referencing values from base.ini

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,7 +280,7 @@ All config settings must be declared in "config/base.ini", even if they are null
 - `AZURE_CALC_SECRET`: The secret key used to generate a token for the Azure pricing calculator
 - `AZURE_CALC_URL`: The redirect URL for the Azure pricing calculator.
 - `AZURE_LOGIN_URL`: The URL used to login for an Azure instance.
-- `AZURE_POWERSHELL_CLIENT_ID`: This client id is set to a value [hardcoded by Microsoft](https://docs.microsoft.com/en-us/azure-stack/user/azure-stack-rest-api-use?view=azs-2008#example) for making API calls
+- `AZURE_POWERSHELL_CLIENT_ID`: This contains [a well-known ApplicationID made publicly available my Microsoft](https://docs.microsoft.com/en-us/azure-stack/user/azure-stack-rest-api-use?view=azs-2008#example) for the purpose of making API requests to Azure via the PowerShell application.
 - `AZURE_STORAGE_KEY`: A valid secret key for the Azure blob storage account.
 - `AZURE_TO_BUCKET_NAME`: The Azure blob storage container name for task order uploads.
 - `BLOB_STORAGE_URL`: URL to Azure blob storage container.

--- a/atat/domain/csp/cloud/azure_cloud_provider.py
+++ b/atat/domain/csp/cloud/azure_cloud_provider.py
@@ -198,8 +198,6 @@ class AzureCloudProvider(CloudProviderInterface):
         self.root_tenant_id = config["AZURE_TENANT_ID"]
         self.vault_url = config["AZURE_VAULT_URL"]
         self.powershell_client_id = config["AZURE_POWERSHELL_CLIENT_ID"]
-        self.graph_resource = self.sdk.cloud.endpoints.microsoft_graph_resource_id
-        self.graph_scope = self.graph_resource + ".default"
         self.default_aadp_qty = config["AZURE_AADP_QTY"]
         self.roles = {
             "owner": config["AZURE_ROLE_DEF_ID_OWNER"],
@@ -212,6 +210,8 @@ class AzureCloudProvider(CloudProviderInterface):
         else:
             self.sdk = azure_sdk_provider
 
+        self.graph_resource = self.sdk.cloud.endpoints.microsoft_graph_resource_id
+        self.graph_scope = self.graph_resource + ".default"
         self.policy_manager = AzurePolicyManager(config["AZURE_POLICY_LOCATION"])
 
     @log_and_raise_exceptions

--- a/atat/domain/csp/cloud/azure_cloud_provider.py
+++ b/atat/domain/csp/cloud/azure_cloud_provider.py
@@ -199,7 +199,7 @@ class AzureCloudProvider(CloudProviderInterface):
         self.vault_url = config["AZURE_VAULT_URL"]
         self.powershell_client_id = config["AZURE_POWERSHELL_CLIENT_ID"]
         self.graph_resource = self.sdk.cloud.endpoints.microsoft_graph_resource_id
-        self.graph_scope = config["AZURE_GRAPH_RESOURCE"] + DEFAULT_SCOPE_SUFFIX
+        self.graph_scope = self.graph_resource + ".default"
         self.default_aadp_qty = config["AZURE_AADP_QTY"]
         self.roles = {
             "owner": config["AZURE_ROLE_DEF_ID_OWNER"],

--- a/atat/domain/csp/cloud/azure_cloud_provider.py
+++ b/atat/domain/csp/cloud/azure_cloud_provider.py
@@ -7,7 +7,6 @@ import time
 from contextlib import contextmanager
 from enum import Enum
 from functools import wraps
-from msrestazure.azure_cloud import AZURE_PUBLIC_CLOUD
 from secrets import token_hex, token_urlsafe
 from typing import Dict, Optional, Tuple
 from urllib.parse import urljoin
@@ -199,7 +198,7 @@ class AzureCloudProvider(CloudProviderInterface):
         self.root_tenant_id = config["AZURE_TENANT_ID"]
         self.vault_url = config["AZURE_VAULT_URL"]
         self.powershell_client_id = config["AZURE_POWERSHELL_CLIENT_ID"]
-        self.graph_resource = AZURE_PUBLIC_CLOUD.endpoints.microsoft_graph_resource_id
+        self.graph_resource = self.sdk.cloud.endpoints.microsoft_graph_resource_id
         self.graph_scope = config["AZURE_GRAPH_RESOURCE"] + DEFAULT_SCOPE_SUFFIX
         self.default_aadp_qty = config["AZURE_AADP_QTY"]
         self.roles = {

--- a/atat/domain/csp/cloud/azure_cloud_provider.py
+++ b/atat/domain/csp/cloud/azure_cloud_provider.py
@@ -7,6 +7,7 @@ import time
 from contextlib import contextmanager
 from enum import Enum
 from functools import wraps
+from msrestazure.azure_cloud import AZURE_PUBLIC_CLOUD
 from secrets import token_hex, token_urlsafe
 from typing import Dict, Optional, Tuple
 from urllib.parse import urljoin
@@ -198,7 +199,7 @@ class AzureCloudProvider(CloudProviderInterface):
         self.root_tenant_id = config["AZURE_TENANT_ID"]
         self.vault_url = config["AZURE_VAULT_URL"]
         self.powershell_client_id = config["AZURE_POWERSHELL_CLIENT_ID"]
-        self.graph_resource = config["AZURE_GRAPH_RESOURCE"]
+        self.graph_resource = AZURE_PUBLIC_CLOUD.endpoints.microsoft_graph_resource_id
         self.graph_scope = config["AZURE_GRAPH_RESOURCE"] + DEFAULT_SCOPE_SUFFIX
         self.default_aadp_qty = config["AZURE_AADP_QTY"]
         self.roles = {
@@ -1092,7 +1093,7 @@ class AzureCloudProvider(CloudProviderInterface):
         request_body = {"displayName": payload.tenant_principal_app_display_name}
 
         result = self.sdk.requests.post(
-            f"{self.graph_resource}/v1.0/applications",
+            f"{self.graph_resource}v1.0/applications",
             json=request_body,
             headers=make_auth_header(graph_token),
             timeout=30,
@@ -1112,7 +1113,7 @@ class AzureCloudProvider(CloudProviderInterface):
         graph_token = self._get_tenant_admin_token(payload.tenant_id, self.graph_scope)
         request_body = {"appId": payload.principal_app_id}
 
-        url = f"{self.graph_resource}/v1.0/servicePrincipals"
+        url = f"{self.graph_resource}v1.0/servicePrincipals"
 
         result = self.sdk.requests.post(
             url,
@@ -1137,7 +1138,7 @@ class AzureCloudProvider(CloudProviderInterface):
         }
 
         response = self.sdk.requests.post(
-            f"{self.graph_resource}/v1.0/applications/{payload.principal_app_object_id}/addPassword",
+            f"{self.graph_resource}v1.0/applications/{payload.principal_app_object_id}/addPassword",
             json=request_body,
             headers=make_auth_header(graph_token),
             timeout=30,
@@ -1179,7 +1180,7 @@ class AzureCloudProvider(CloudProviderInterface):
         }
 
         response = self.sdk.requests.post(
-            f"{self.graph_resource}/v1.0/servicePrincipals/{payload.principal_id}/appRoleAssignments",
+            f"{self.graph_resource}v1.0/servicePrincipals/{payload.principal_id}/appRoleAssignments",
             json=request_body,
             headers=make_auth_header(graph_token),
         )
@@ -1253,7 +1254,7 @@ class AzureCloudProvider(CloudProviderInterface):
             registration and the app role id for "Directory.ReadWrite.All"
         """
         response = self.sdk.requests.get(
-            f"{self.graph_resource}/v1.0/servicePrincipals",
+            f"{self.graph_resource}v1.0/servicePrincipals",
             params={
                 FILTER_MAP_KEY: f"servicePrincipalNames/any(name:name eq '{GRAPH_API_APPLICATION_ID}')"
             },
@@ -1272,7 +1273,7 @@ class AzureCloudProvider(CloudProviderInterface):
 
         graph_token = self._get_tenant_admin_token(payload.tenant_id, self.graph_scope)
 
-        url = f"{self.graph_resource}/beta/roleManagement/directory/roleDefinitions"
+        url = f"{self.graph_resource}beta/roleManagement/directory/roleDefinitions"
 
         response = self.sdk.requests.get(
             url, headers=make_auth_header(graph_token), timeout=30
@@ -1309,7 +1310,7 @@ class AzureCloudProvider(CloudProviderInterface):
             "directoryScopeId": "/",
         }
 
-        url = f"{self.graph_resource}/beta/roleManagement/directory/roleAssignments"
+        url = f"{self.graph_resource}beta/roleManagement/directory/roleAssignments"
 
         result = self.sdk.requests.post(
             url,
@@ -1322,7 +1323,7 @@ class AzureCloudProvider(CloudProviderInterface):
 
     @log_and_raise_exceptions
     def _get_billing_admin_role_template_id(self, graph_token):
-        url = f"{self.graph_resource}/v1.0/directoryRoleTemplates"
+        url = f"{self.graph_resource}v1.0/directoryRoleTemplates"
         response = self.sdk.requests.get(url, headers=make_auth_header(graph_token))
         response.raise_for_status()
         try:
@@ -1342,7 +1343,7 @@ class AzureCloudProvider(CloudProviderInterface):
     @log_and_raise_exceptions
     def _activate_billing_admin_role(self, graph_token, role_template_id):
         request_body = {"roleTemplateId": role_template_id}
-        url = f"{self.graph_resource}/v1.0/directoryRoles"
+        url = f"{self.graph_resource}v1.0/directoryRoles"
         response = self.sdk.requests.post(
             url, headers=make_auth_header(graph_token), json=request_body
         )
@@ -1362,7 +1363,7 @@ class AzureCloudProvider(CloudProviderInterface):
     def _get_existing_billing_owner(
         self, token: str, payload: BillingOwnerCSPPayload
     ) -> Optional[UserCSPResult]:
-        url = f"{self.graph_resource}/v1.0/users/{payload.user_principal_name}"
+        url = f"{self.graph_resource}v1.0/users/{payload.user_principal_name}"
         result = self.sdk.requests.get(url, headers=make_auth_header(token))
         if result.status_code == 200:
             return UserCSPResult(**result.json())
@@ -1410,7 +1411,7 @@ class AzureCloudProvider(CloudProviderInterface):
             "directoryScopeId": "/",
         }
 
-        url = f"{self.graph_resource}/beta/roleManagement/directory/roleAssignments"
+        url = f"{self.graph_resource}beta/roleManagement/directory/roleAssignments"
         result = self.sdk.requests.post(
             url, headers=make_auth_header(graph_token), json=request_body
         )
@@ -1422,7 +1423,7 @@ class AzureCloudProvider(CloudProviderInterface):
 
     @log_and_raise_exceptions
     def _get_billing_owner_role(self, graph_token):
-        url = f"{self.graph_resource}/v1.0/directoryRoles"
+        url = f"{self.graph_resource}v1.0/directoryRoles"
         result = self.sdk.requests.get(url, headers=make_auth_header(graph_token))
         result.raise_for_status()
         result = result.json()
@@ -1464,7 +1465,7 @@ class AzureCloudProvider(CloudProviderInterface):
             "invitedUserType": "Member",
         }
 
-        url = f"{self.graph_resource}/v1.0/invitations"
+        url = f"{self.graph_resource}v1.0/invitations"
         response = self.sdk.requests.post(
             url, json=body, headers=make_auth_header(graph_token)
         )
@@ -1483,7 +1484,7 @@ class AzureCloudProvider(CloudProviderInterface):
     def _update_active_directory_user_email(self, graph_token, user_id, payload):
         request_body = {"otherMails": [payload.email]}
 
-        url = f"{self.graph_resource}/v1.0/users/{user_id}"
+        url = f"{self.graph_resource}v1.0/users/{user_id}"
 
         result = self.sdk.requests.patch(
             url,
@@ -1504,7 +1505,7 @@ class AzureCloudProvider(CloudProviderInterface):
             }
         }
 
-        url = f"{self.graph_resource}/v1.0/users/{payload.user_object_id}"
+        url = f"{self.graph_resource}v1.0/users/{payload.user_object_id}"
 
         result = self.sdk.requests.patch(
             url,

--- a/config/base.ini
+++ b/config/base.ini
@@ -12,7 +12,6 @@ AZURE_CALC_RESOURCE=https://azurecom.onmicrosoft.com/acom-prod/
 AZURE_CALC_SECRET
 AZURE_CALC_URL=https://azure.microsoft.com/en-us/pricing/calculator/
 AZURE_CLIENT_ID
-AZURE_GRAPH_RESOURCE=https://graph.microsoft.com
 AZURE_LOGIN_URL=https://portal.azure.com/
 AZURE_POLICY_LOCATION=policies
 AZURE_POWERSHELL_CLIENT_ID=1950a258-227b-4e31-a9cf-717495945fc2

--- a/script/add_users_to_aad_tenant.py
+++ b/script/add_users_to_aad_tenant.py
@@ -18,9 +18,10 @@ from atat.domain.csp.cloud.utils import (
     create_active_directory_user,
 )
 from atat.domain.csp.cloud.models import ServicePrincipalTokenPayload, UserCSPPayload
+from msrestazure.azure_cloud import AZURE_PUBLIC_CLOUD
 
-GRAPH_RESOURCE = "https://graph.microsoft.com"
-TOKEN_SCOPE = GRAPH_RESOURCE + "/.default"
+GRAPH_RESOURCE_ENDPOINT = AZURE_PUBLIC_CLOUD.endpoints.microsoft_graph_resource_id
+TOKEN_SCOPE = GRAPH_RESOURCE_ENDPOINT + ".default"
 
 
 def get_token(scope, client_id, client_secret, tenant_id):
@@ -47,7 +48,7 @@ def create_user(token, tenant_id, tenant_host_name):
         last_name=last_name,
     )
     response = create_active_directory_user(
-        token, GRAPH_RESOURCE, payload, password_reset=False
+        token, GRAPH_RESOURCE_ENDPOINT, payload, password_reset=False
     )
     response.raise_for_status()
     result = payload.dict()

--- a/script/teardown_hybrid.py
+++ b/script/teardown_hybrid.py
@@ -11,12 +11,15 @@ from atat.domain.csp.cloud.utils import get_principal_auth_token, make_auth_head
 from atat.domain.csp.cloud.models import UserPrincipalTokenPayload
 from msrestazure.azure_cloud import AZURE_PUBLIC_CLOUD
 
+# these contain trailing forward slash
+GRAPH_RESOURCE_ENDPOINT = AZURE_PUBLIC_CLOUD.endpoints.microsoft_graph_resource_id
+RESOURCE_MANAGER_ENDPOINT = AZURE_PUBLIC_CLOUD.endpoints.resource_manager
 
-GRAPH_API = "https://graph.microsoft.com"
 
+DEFAULT_SCOPE_SUFFIX = ".default"
 
 def delete_tenant_principal_app(token, app_id):
-    url = f"{GRAPH_API}/v1.0/applications/{app_id}"
+    url = f"{GRAPH_RESOURCE_ENDPOINT}v1.0/applications/{app_id}"
 
     response = requests.delete(url, headers=make_auth_header(token))
     response.raise_for_status()
@@ -24,7 +27,7 @@ def delete_tenant_principal_app(token, app_id):
 
 def list_app_registrations(token):
 
-    url = f"{GRAPH_API}/v1.0/applications"
+    url = f"{GRAPH_RESOURCE_ENDPOINT}v1.0/applications"
     response = requests.get(url, headers=make_auth_header(token))
     response.raise_for_status()
 
@@ -50,7 +53,7 @@ def delete_app_registrations(token):
 
 def list_management_groups(token):
     response = requests.get(
-        "https://management.azure.com/providers/Microsoft.Management/managementGroups?api-version=2020-02-01",
+        f"{RESOURCE_MANAGER_ENDPOINT}providers/Microsoft.Management/managementGroups?api-version=2020-02-01",
         headers=make_auth_header(token),
     )
     response.raise_for_status()
@@ -65,7 +68,7 @@ def list_management_groups(token):
 
 def delete_management_group(token, mgmt_group_id):
     response = requests.delete(
-        f"https://management.azure.com/providers/Microsoft.Management/managementGroups/{mgmt_group_id}?api-version=2020-02-01",
+        f"{RESOURCE_MANAGER_ENDPOINT}providers/Microsoft.Management/managementGroups/{mgmt_group_id}?api-version=2020-02-01",
         headers=make_auth_header(token),
     )
     response.raise_for_status()
@@ -110,7 +113,7 @@ if __name__ == "__main__":
         client_id=ps_client_id,
         username=username,
         password=password,
-        scope=GRAPH_API + "/.default",
+        scope=GRAPH_RESOURCE_ENDPOINT + DEFAULT_SCOPE_SUFFIX,
     )
     graph_token = get_principal_auth_token(tenant_id, payload)
     delete_app_registrations(graph_token)
@@ -120,7 +123,7 @@ if __name__ == "__main__":
         client_id=ps_client_id,
         username=username,
         password=password,
-        scope=AZURE_PUBLIC_CLOUD.endpoints.resource_manager + "/.default",
+        scope=RESOURCE_MANAGER_ENDPOINT + DEFAULT_SCOPE_SUFFIX,
     )
     resource_token = get_principal_auth_token(tenant_id, payload)
     delete_management_groups(resource_token)

--- a/script/teardown_hybrid.py
+++ b/script/teardown_hybrid.py
@@ -18,6 +18,7 @@ RESOURCE_MANAGER_ENDPOINT = AZURE_PUBLIC_CLOUD.endpoints.resource_manager
 
 DEFAULT_SCOPE_SUFFIX = ".default"
 
+
 def delete_tenant_principal_app(token, app_id):
     url = f"{GRAPH_RESOURCE_ENDPOINT}v1.0/applications/{app_id}"
 


### PR DESCRIPTION
1. Removed  `AZURE_GRAPH_RESOURCE` from _base.ini_ instead referencing `AZURE_PUBLIC_CLOUD.endpoints.microsoft_graph_resource_id` from package `msrestazure`
2. Adjustments from the above because the new value `https://graph.microsoft.com/` includes a trailing forward-slash, and the old value did not
3. Similar to the above, made use of `AZURE_PUBLIC_CLOUD.endpoints.resource_manager` from package `msrestazure`
4. Improved description of `AZURE_POWERSHELL_CLIENT_ID` in readme.  There is no meaningful use of the value 1950a258-227b-4e31-a9cf-717495945fc2 that can be replaced with a reference to the definitive occurrence in file base.ini

Within file _azure_cloud_provider.py_ the referenced endpoints from package `msrestazure` are already conveniently available from `self.sdk.cloud.endpoints`.  We should make more use of these.

In some cases the forward-slashes before default scopes had to have been duplicated.  I imagine we'll find more of this. 


Ticket: AT-6033