### PR TITLE
Fix accessibility issue focusing on the first portfolio link  

### DIFF
--- a/styles/elements/_sidenav.scss
+++ b/styles/elements/_sidenav.scss
@@ -113,7 +113,7 @@
 
     &:focus {
       position: relative;
-      z-index: auto;
+      z-index: 1;
     }
 
     &--active {

--- a/styles/elements/_sidenav.scss
+++ b/styles/elements/_sidenav.scss
@@ -83,7 +83,7 @@
     width: $sidenav-expanded-width;
     background-color: $color-white;
     list-style: none;
-    padding: 0 0 ($gap * 2) 0;
+    padding: ($gap * 2) 0 ($gap * 2) 0;
 
     &--no-header {
       top: $topbar-height + $usa-banner-height;
@@ -97,7 +97,6 @@
   }
 
   &__item {
-    padding-top: 6px;
     margin: 0;
     display: block;
     color: $color-black-light !important;

--- a/styles/elements/_sidenav.scss
+++ b/styles/elements/_sidenav.scss
@@ -111,6 +111,11 @@
     text-decoration: none;
     text-overflow: ellipsis;
 
+    &:focus {
+      position: relative;
+      z-index: auto;
+    }
+
     &--active {
       font-size: $base-font-size;
       font-weight: $font-bold;

--- a/styles/elements/_sidenav.scss
+++ b/styles/elements/_sidenav.scss
@@ -97,6 +97,7 @@
   }
 
   &__item {
+    padding-top: 6px;
     margin: 0;
     display: block;
     color: $color-black-light !important;


### PR DESCRIPTION
The sidenav link had issues focusing on the first link when the second portfolio is selected. This brings the focus up to the front when focused on through tabbing in the keyboard.

AT-5116