### PR TITLE
AT-6014 Update JavaScript tests to eliminate use of deprecated functions from Vue Test Utils (VTU) library

### DIFF
--- a/js/components/__tests__/multi_checkbox_input.test.js
+++ b/js/components/__tests__/multi_checkbox_input.test.js
@@ -79,8 +79,8 @@ describe('Multicheckbox shows validation states correctly', () => {
     await checkboxA.setChecked()
     await checkboxA.setChecked(false)
 
-    expect(wrapper.contains('.usa-input--error')).toBe(true)
-    expect(wrapper.contains('.usa-input--success')).toBe(false)
+    expect(wrapper.find('.usa-input--error').exists()).toBe(true)
+    expect(wrapper.find('.usa-input--success').exists()).toBe(false)
   })
 
   it('Should be valid when no checkboxes are checked but it is optional', async () => {

--- a/js/components/__tests__/multi_checkbox_input.test.js
+++ b/js/components/__tests__/multi_checkbox_input.test.js
@@ -23,8 +23,8 @@ describe('MultiCheckboxInput Renders Correctly', () => {
         },
       },
     })
-    expect(wrapper.contains('.usa-input--success')).toBe(false)
-    expect(wrapper.contains('.usa-input--error')).toBe(false)
+    expect(wrapper.find('.usa-input--success').exists()).toBe(false)
+    expect(wrapper.find('.usa-input--error').exists()).toBe(false)
     expect(wrapper.find('.usa-input input[value="a"]').element.checked).toBe(
       false
     )
@@ -60,8 +60,8 @@ describe('Multicheckbox shows validation states correctly', () => {
       },
     })
     await wrapper.find('.usa-input input[value="a"]').setChecked()
-    expect(wrapper.contains('.usa-input--success')).toBe(true)
-    expect(wrapper.contains('.usa-input--error')).toBe(false)
+    expect(wrapper.find('.usa-input--success').exists()).toBe(true)
+    expect(wrapper.find('.usa-input--error').exists()).toBe(false)
   })
 
   it('Should be invalid when no checkboxes are checked', async () => {
@@ -96,7 +96,7 @@ describe('Multicheckbox shows validation states correctly', () => {
     await checkboxA.setChecked()
     await checkboxA.setChecked(false)
 
-    expect(wrapper.contains('.usa-input--error')).toBe(false)
-    expect(wrapper.contains('.usa-input--success')).toBe(true)
+    expect(wrapper.find('.usa-input--error').exists()).toBe(false)
+    expect(wrapper.find('.usa-input--success').exists()).toBe(true)
   })
 })

--- a/js/components/__tests__/options_input.test.js
+++ b/js/components/__tests__/options_input.test.js
@@ -55,8 +55,8 @@ describe('SelectInput Renders Correctly', () => {
 
     await wrapper.find('select#selectfield').trigger('change')
 
-    expect(wrapper.contains('.usa-input--error')).toBe(true)
-    expect(wrapper.contains('.usa-input--success')).toBe(false)
+    expect(wrapper.find('.usa-input--error').exists()).toBe(true)
+    expect(wrapper.find('.usa-input--success').exists()).toBe(false)
   })
 
   it('Should be considered valid if value is selected', async () => {
@@ -74,8 +74,8 @@ describe('SelectInput Renders Correctly', () => {
     await wrapper.find('option[value="a"]').setSelected()
     await selectField.trigger('change')
 
-    expect(wrapper.contains('.usa-input--error')).toBe(false)
-    expect(wrapper.contains('.usa-input--success')).toBe(true)
+    expect(wrapper.find('.usa-input--error').exists()).toBe(false)
+    expect(wrapper.find('.usa-input--success').exists()).toBe(true)
   })
 })
 
@@ -149,7 +149,7 @@ describe('RadioInput Renders Correctly', () => {
 
     await wrapper.findAll('input[type="radio"]').at(0).setChecked()
 
-    expect(wrapper.contains('.usa-input--error')).toBe(false)
-    expect(wrapper.contains('.usa-input--success')).toBe(true)
+    expect(wrapper.find('.usa-input--error').exists()).toBe(false)
+    expect(wrapper.find('.usa-input--success').exists()).toBe(true)
   })
 })

--- a/js/components/__tests__/text_input.test.js
+++ b/js/components/__tests__/text_input.test.js
@@ -26,11 +26,11 @@ describe('TextInput Validates Correctly', () => {
           },
         },
       })
-      expect(wrapper.contains('.usa-input--success')).toBe(false)
-      expect(wrapper.contains('.usa-input--error')).toBe(false)
-      expect(wrapper.contains('.usa-input--validation--taskOrderNumber')).toBe(
-        true
-      )
+      expect(wrapper.find('.usa-input--success').exists()).toBe(false)
+      expect(wrapper.find('.usa-input--error').exists()).toBe(false)
+      expect(
+        wrapper.find('.usa-input--validation--taskOrderNumber').exists()
+      ).toBe(true)
     })
 
     it('Should allow valid TO numbers', async () => {
@@ -60,8 +60,8 @@ describe('TextInput Validates Correctly', () => {
         // manually trigger change event in hidden fields
         await hiddenField.trigger('change')
         // check for validation classes
-        expect(wrapper.contains('.usa-input--success')).toBe(true)
-        expect(wrapper.contains('.usa-input--error')).toBe(false)
+        expect(wrapper.find('.usa-input--success').exists()).toBe(true)
+        expect(wrapper.find('.usa-input--error').exists()).toBe(false)
       }
     })
 
@@ -90,8 +90,8 @@ describe('TextInput Validates Correctly', () => {
         // manually trigger change event in hidden fields
         await hiddenField.trigger('change')
         // check for validation classes
-        expect(wrapper.contains('.usa-input--success')).toBe(false)
-        expect(wrapper.contains('.usa-input--error')).toBe(true)
+        expect(wrapper.find('.usa-input--success').exists()).toBe(false)
+        expect(wrapper.find('.usa-input--error').exists()).toBe(true)
       }
     })
   })

--- a/js/components/__tests__/upload_input.test.js
+++ b/js/components/__tests__/upload_input.test.js
@@ -69,7 +69,7 @@ describe('UploadInput Test', () => {
       },
     })
 
-    const component = wrapper.find(uploadinput)
+    const component = wrapper.findComponent(uploadinput)
     const event = { target: { value: '', files: [{ name: 'sample.pdf' }] } }
 
     component.setMethods({
@@ -91,7 +91,7 @@ describe('UploadInput Test', () => {
     })
 
     const event = { preventDefault: () => {}, target: { value: 'val' } }
-    const component = wrapper.find(uploadinput)
+    const component = wrapper.findComponent(uploadinput)
 
     component.vm.removeAttachment(event)
 

--- a/js/components/forms/__tests__/to_form.test.js
+++ b/js/components/forms/__tests__/to_form.test.js
@@ -10,16 +10,16 @@ const TOFormWrapper = makeTestWrapper({
   templatePath: 'to_form.html',
 })
 
-describe('TOForm Test', async () => {
+describe('TOForm Test', () => {
   it('should allow users to add new CLINs', async () => {
     const wrapper = mount(TOFormWrapper, {
       propsData: {
         initialData: {},
       },
     })
-    expect(wrapper.findAll(clinFields).length).toBe(1)
+    expect(wrapper.findAllComponents(clinFields).length).toBe(1)
     await wrapper.find('#add-clin').trigger('click')
-    expect(wrapper.findAll(clinFields).length).toBe(2)
+    expect(wrapper.findAllComponents(clinFields).length).toBe(2)
   })
 
   it('should not enable the save button until the form is complete and valid', async () => {


### PR DESCRIPTION
Replaced deprecated methods from Vue Test Utils (VTU) library with recommended methods.

The remaining deprecation warning is related to the use of [this method](https://vue-test-utils.vuejs.org/api/wrapper/setmethods.html).

Ticket: AT-6014