### PR TITLE
Revert "feature/AT-6163 removed unused markers"

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -5,6 +5,11 @@ env =
 addopts = --ignore=tests/acceptance/ --cov=atat --cov-report term-missing --cov-fail-under 90
 
 markers =
+  audit_log: Tests for the audit log, which is behind a feature flag at the moment. Enable these tests by setting `USE_AUDIT_LOG = true`
+  state_machine: Tests related to state machines
+  hybrid: Integration tests for the Hybrid Cloud Provider. These tests are skipped by default -- enable them by adding a `--hybrid` flag
+  subscriptions: Integration tests related to subscription creation. These tests are skipped by default -- enable them by adding a `--subscriptions` flag
+  access_check: An access check test
   smoke: minimal set of tests to test software functionalities and verifying whether the important features are working and there are no showstoppers
   regression: re-running functional and non-functional tests to ensure that previously developed and tested software still performs after a change
   AT6163: tests for ticket 6163


### PR DESCRIPTION
This partially reverts commit a34a979defba88c64226f0ec2afb988bcdf9ff11 from #2270.

This change seems to have been introduced because the markers are not used in the UI tests; however, they are used in the regular application unit tests (in the `tests/` directory). Without these, `pytest` will emit a warning about unregistered markers. This is the cause of more verbose output in the recent CI runs. Adding these back in removes the warnings and ensures that any `PytestUnknownMarkWarning` we see are actually due to misspellings or other errors.

The initial commit correctly added the `daily` marker which is not removed during this revert.