### PR TITLE
Fix typo to appease dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,7 +20,7 @@ updates:
     directory: "/"
     schedule:
       interval: daily
-    open-pull-request-limit: 10
+    open-pull-requests-limit: 10
     labels:
       - dependencies
       - github-actions


### PR DESCRIPTION
Dependabot seems to be grumbling on all our PRs because of this typo. I
have run the config file as-is through the validator at
https://dependabot.com/docs/config-file-beta/validator/ and it does not
report any issues with this updated config