### PR TITLE
Fix application invite success message to use first and last name

### DIFF
--- a/atat/routes/applications/settings.py
+++ b/atat/routes/applications/settings.py
@@ -509,7 +509,10 @@ def resend_invite(application_id, application_role_id):
             token=new_invite.token,
         )
 
-        flash("application_invite_resent", email=new_invite.email)
+        flash(
+            "application_invite_resent",
+            name=new_invite.first_name + " " + new_invite.last_name,
+        )
     else:
         flash(
             "application_invite_error",

--- a/translations.yaml
+++ b/translations.yaml
@@ -134,7 +134,7 @@ flash:
       title: Application invitation error
       message: There was an error processing the invitation for {user_name} from {application_name}
     resent:
-      message: "{email} has been sent an invitation to access this Application"
+      message: "{name} has been sent an invitation to access this Application"
   application_member:
     removed:
       title: Team member removed from application


### PR DESCRIPTION
Changed the application invite success message from using email address to using first and last name.

![image](https://user-images.githubusercontent.com/77642966/116735336-57633f80-a9bc-11eb-999f-f3001d293d38.png)

Ticket: AT-4990