### PR TITLE
Fix initial application invite success message to use first and last name

### DIFF
--- a/atat/routes/applications/settings.py
+++ b/atat/routes/applications/settings.py
@@ -211,7 +211,10 @@ def handle_create_member(application_id, form_data):
                 token=invite.token,
             )
 
-            flash("new_application_member", user_name=invite.first_name)
+            flash(
+                "new_application_member",
+                user_name=invite.first_name + " " + invite.last_name,
+            )
 
         except AlreadyExistsError:
             return render_template(


### PR DESCRIPTION
Changed the initial application invite success message from using email address to using first and last name.
This makes the initial message consistent with the re-send message.

Ticket: AT-4990