### PR TITLE
Ignore node_modules in Sonar

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,14 +1,38 @@
 # See https://sonarcloud.io/documentation/analysis/analysis-parameters/
 # for further information on these parameters
-
 sonar.host.url=https://sonarcloud.io
 sonar.projectKey=dod-ccpo_atat
 sonar.organization=dod-ccpo
 sonar.javascript.lcov.reportPaths=coverage/lcov.info
 sonar.python.coverage.reportPaths=coverage.xml
-sonar.exclusions=uitests/**,tests/**,coverage/**,js/test_templates/**,load-test/**
+sonar.exclusions=\
+    coverage/**,\
+    load-test/**,\
+    node_modules/**,\
+    tests/**,\
+    uitests/**,\
+    js/test_templates/**
 # Files that are tests or are not application code are not reported on for coverage.
 # Additionally, there are some files that have been excluded from test coverage reports
 # and those same files are excluded from this list as well.
-sonar.coverage.exclusions=tests/**,alembic/**,js/**/tests/**,js/**/__tests__/**,ansible/**,uitests/**,ops/**,deploy/**,script/**,alembic/**,docs/**,sample-server/**,load-test/**,atat/routes/dev.py,atat/domain/audit_log.py,atat/models/mixins/auditable.py,atat/models/audit_event.py,atat/domain/csp/cloud/hybrid_cloud_provider.py
-sonar.cpd.exclusions=alembic/**,js/**/__tests__/**
+sonar.coverage.exclusions=\
+    alembic/**,\
+    ansible/**,\
+    deploy/**,\
+    docs/**,\
+    load-test/**,\
+    ops/**,\
+    sample-server/**,\
+    script/**,\
+    tests/**,\
+    js/**/tests/**,\
+    js/**/__tests__/**,\
+    uitests/**,\
+    atat/routes/dev.py,\
+    atat/domain/audit_log.py,\
+    atat/models/mixins/auditable.py,\
+    atat/models/audit_event.py,\
+    atat/domain/csp/cloud/hybrid_cloud_provider.py
+sonar.cpd.exclusions=\
+    alembic/**,\
+    js/**/__tests__/**


### PR DESCRIPTION
It seems like we're getting some failures from files within this directory getting scanned