### PR TITLE
Fix SonarCloud PR reporting

### DIFF
--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -42,7 +42,10 @@ jobs:
         run: unzip ../coverage.zip -d ..
       - name: Read the GIT reference used for the CI tests
         run: |
-          echo "git_ref=$(cat ../ref.txt)" >> $GITHUB_ENV
+          echo "GIT_REF=$(cat ../pr/ref)" >> $GITHUB_ENV
+          echo "PR_BASE_REF=$(cat ../pr/base" >> $GITHUB_ENV
+          echo "PR_SOURCE_REF=$(cat ../pr/source)" >> $GITHUB_ENV
+          echo "PR_ID=$(cat ../pr/num)" >> $GITHUB_ENV
       - name: Checkout Code
         # In general, checking out the code here, where we may have come from an untrusted context
         # would be a red flag. In this scenario, we will not be running the malicious code; just
@@ -50,7 +53,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
-          ref: ${{ env.git_ref }}
+          ref: ${{ env.GIT_REF }}
       - name: Copy coverage reports
         run: |
           mv ../coverage .
@@ -60,3 +63,8 @@ jobs:
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          args: >
+            -Dsonar.pullrequest.key=${{ env.PR_ID }}
+            -Dsonar.pullrequest.branch=${{ env.PR_SOURCE_REF }}
+            -Dsonar.pullrequest.base=${{ env.PR_BASE_REF }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -91,9 +91,13 @@ jobs:
           PGHOST: localhost
           PGPORT: 5432
           REDIS_HOST: localhost:6379
-      - name: Save github SHA
+      - name: Save GitHub Context Information
         run: |
-          printf ${{ github.ref }} > ./ref.txt
+          mkdir -p pr
+          printf ${{ github.ref }} > ./pr/ref
+          printf ${{ github.base_ref }} > ./pr/base
+          printf ${{ github.head_ref }} > ./pr/source
+          printf ${{ github.event.number }} > ./pr/num
       - name: Upload coverage report artifact
         uses: actions/upload-artifact@v2
         with:
@@ -101,4 +105,4 @@ jobs:
           path: |
             coverage.xml
             coverage/lcov.info
-            ref.txt
+            pr/*


### PR DESCRIPTION
When run outside the `pull_request` context, the variables that Sonar
Scanner uses to determine the pull request information are not available
in the `github` context object. Those need to be provided manually and
must be passed from the earlier workflow stage. They can be provided in
the output artifact in the same way that the ref and coverage reports
are.