### PR TITLE
AT-6181 Step-by-Step [Next/Cancel] walkthrough of application is not accessible

### DIFF
--- a/templates/applications/fragments/add_new_environment.html
+++ b/templates/applications/fragments/add_new_environment.html
@@ -16,14 +16,20 @@
             {{ TextInput(new_env_form.name, label="", validation="defaultStringField", optional=False) }}
           <div class="action-group">
             {{ SaveButton(text=('common.save' | translate), element="input", form="add-new-env") }}
-            <a class='action-group__action icon-link icon-link--default' v-on:click="toggle">
+            <a class='action-group__action icon-link icon-link--default'
+               v-on:click="toggle"
+               tabindex=0
+               role="button">
               {{ "common.cancel" | translate }}
             </a>
           </div>
         </div>
       </form>
     </div>
-    <a class="usa-button usa-button-secondary add-new-button" v-on:click="toggle">
+    <a class="usa-button usa-button-secondary add-new-button"
+       tabindex=0
+       role="button"
+       v-on:click="toggle">
       {{ "portfolios.applications.add_environment" | translate }}
     </a>
   </div>

--- a/templates/applications/fragments/members.html
+++ b/templates/applications/fragments/members.html
@@ -85,8 +85,15 @@
             <hr class="full-width">
             {{ "invites.revoke_modal_text" | translate({"application": application.name}) }}
             <div class="action-group">
-              <button class="action-group__action usa-button usa-button-primary" type="submit">{{ "invites.revoke" | translate }}</button>
-              <button class='action-group__action usa-button usa-button-secondary' v-on:click='closeModal("{{revoke_invite_modal}}")' type="button">{{ "common.cancel" | translate }}</button>
+              <button class="action-group__action usa-button usa-button-primary"
+                      tabindex=0
+                      role="button"
+                      type="submit">{{ "invites.revoke" | translate }}</button>
+              <button class='action-group__action usa-button usa-button-secondary'
+                      v-on:click='closeModal("{{revoke_invite_modal}}")'
+                      tabindex=0
+                      role="button"
+                      type="button">{{ "common.cancel" | translate }}</button>
             </div>
           </form>
         {% endcall %}

--- a/templates/applications/new/step_1.html
+++ b/templates/applications/new/step_1.html
@@ -46,8 +46,10 @@
           {% block next_button %}
             {{ SaveButton(text=('portfolios.applications.new.step_1_button_text' | translate)) }}
           {% endblock %}
-          <a href="{{ url_for('applications.portfolio_applications', portfolio_id=portfolio.id) }}">
-            Cancel
+          <a href="{{ url_for('applications.portfolio_applications', portfolio_id=portfolio.id) }}"
+             tabindex=0
+             role="button">
+            {{ "common.cancel" | translate }}
           </a>
         </div>
       </div>

--- a/templates/applications/new/step_2.html
+++ b/templates/applications/new/step_2.html
@@ -68,11 +68,16 @@
           {% block next_button %}
             {{ SaveButton(text=('portfolios.applications.new.step_2_button_text' | translate)) }}
           {% endblock %}
-          <a class="usa-button usa-button-secondary" href="{{ url_for('applications.view_new_application_step_1', application_id=application.id) }}">
+          <a class="usa-button usa-button-secondary"
+             tabindex=0
+             role="button"
+             href="{{ url_for('applications.view_new_application_step_1', application_id=application.id) }}">
             Previous
           </a>
-          <a href="{{ url_for('applications.portfolio_applications', portfolio_id=portfolio.id) }}">
-            Cancel
+          <a href="{{ url_for('applications.portfolio_applications', portfolio_id=portfolio.id) }}"
+             tabindex=0
+             role="button">
+            {{ "common.cancel" | translate }}
           </a>
         </div>
       </div>

--- a/templates/applications/new/step_3.html
+++ b/templates/applications/new/step_3.html
@@ -29,13 +29,21 @@
     class="action-group-footer"
     v-bind:class="{'action-group-footer--expand-offset': this.$root.sidenavExpanded, 'action-group-footer--collapse-offset': !this.$root.sidenavExpanded}">
     <div class="action-group-footer--container">
-      <a class="usa-button" href="{{ url_for('applications.settings', application_id=application_id) }}">
+      <a class="usa-button"
+         tabindex=0
+         role="button"
+         href="{{ url_for('applications.settings', application_id=application_id) }}">
         {{ "portfolios.applications.new.step_3_button_text" | translate }}
       </a>
-      <a class="usa-button usa-button-secondary" href="{{ url_for('applications.view_new_application_step_2', application_id=application.id) }}">
+      <a class="usa-button usa-button-secondary"
+         tabindex=0
+         role="button"
+         href="{{ url_for('applications.view_new_application_step_2', application_id=application.id) }}">
         {{ "common.previous" | translate }}
       </a>
-      <a href="{{ url_for('applications.portfolio_applications', portfolio_id=portfolio.id) }}">
+      <a href="{{ url_for('applications.portfolio_applications', portfolio_id=portfolio.id) }}"
+         tabindex=0
+         role="button">
         {{ "common.cancel" | translate }}
       </a>
     </div>

--- a/templates/ccpo/add_user.html
+++ b/templates/ccpo/add_user.html
@@ -16,7 +16,10 @@
           <div class="form-col form-col--third">
             <div class='action-group'>
               {{ SaveButton(text="common.next"|translate, element="input", additional_classes="action-group__action", form="add-ccpo-user-form") }}
-              <a class='action-group__action icon-link icon-link--default' href="{{ url_for('ccpo.users') }}">{{ "common.cancel" | translate }}</a>
+              <a class='action-group__action icon-link icon-link--default'
+                 tabindex=0
+                 role="button"
+                 href="{{ url_for('ccpo.users') }}">{{ "common.cancel" | translate }}</a>
             </div>
           </div>
         </div>

--- a/templates/ccpo/confirm_user.html
+++ b/templates/ccpo/confirm_user.html
@@ -25,7 +25,10 @@
               type='submit'
               class='action-group__action usa-button'
               value='{{ "ccpo.form.confirm_button" | translate }}'>
-          <a class='action-group__action icon-link icon-link--default' href="{{ url_for('ccpo.users') }}">
+          <a class='action-group__action icon-link icon-link--default'
+             tabindex=0
+             role="button"
+             href="{{ url_for('ccpo.users') }}">
             {{ "common.cancel" | translate }}
           </a>
         </div>

--- a/templates/components/delete_confirmation.html
+++ b/templates/components/delete_confirmation.html
@@ -16,7 +16,10 @@
             {{ delete_text }}
           </button>
         </form>
-        <a v-on:click="deleteText = ''; $root.closeModal('{{ modal_id }}')" class="action-group__action icon-link icon-link--default">{{ "common.cancel" | translate }}</a>
+        <a v-on:click="deleteText = ''; $root.closeModal('{{ modal_id }}')"
+           tabindex=0
+           role="button"
+           class="action-group__action icon-link icon-link--default">{{ "common.cancel" | translate }}</a>
       </div>
     </div>
   </delete-confirmation>

--- a/templates/components/member_form.html
+++ b/templates/components/member_form.html
@@ -15,7 +15,10 @@
           class='action-group__action usa-button usa-button-secondary'
           value='{{ "common.previous" | translate }}'>
     {% endif %}
-    <a class='action-group__action' v-on:click="closeModal('{{ modal }}')">{{ "common.cancel" | translate }}</a>
+    <a class='action-group__action'
+       tabindex=0
+       role="button"
+       v-on:click="closeModal('{{ modal }}')">{{ "common.cancel" | translate }}</a>
   </div>
 {% endmacro %}
 

--- a/templates/portfolios/fragments/portfolio_members.html
+++ b/templates/portfolios/fragments/portfolio_members.html
@@ -82,8 +82,15 @@
             <hr class="full-width">
             {{ "invites.revoke_modal_text" | translate({"application": portfolio.name}) }}
             <div class="action-group">
-              <button class="action-group__action usa-button usa-button-primary" type="submit">{{ "invites.revoke" | translate }}</button>
-              <button class='action-group__action usa-button usa-button-secondary' v-on:click='closeModal("{{revoke_invite_modal}}")' type="button">{{ "common.cancel" | translate }}</button>
+              <button class="action-group__action usa-button usa-button-primary"
+                      tabindex=0
+                      role="button"
+                      type="submit">{{ "invites.revoke" | translate }}</button>
+              <button class='action-group__action usa-button usa-button-secondary'
+                      v-on:click='closeModal("{{revoke_invite_modal}}")'
+                      tabindex=0
+                      role="button"
+                      type="button">{{ "common.cancel" | translate }}</button>
             </div>
           </form>
         {% endcall %}
@@ -106,7 +113,10 @@
                 {{ "portfolios.members.archive_button" | translate }}
               </button>
             </form>
-            <a v-on:click="closeModal('{{ modal_id }}')" class="action-group__action icon-link icon-link--default">{{ "common.cancel" | translate }}</a>
+            <a v-on:click="closeModal('{{ modal_id }}')"
+               tabindex=0
+               role="button"
+               class="action-group__action icon-link icon-link--default">{{ "common.cancel" | translate }}</a>
           </div>
         {% endcall %}
       {%- endif %}

--- a/templates/task_orders/builder_base.html
+++ b/templates/task_orders/builder_base.html
@@ -50,12 +50,16 @@
               <button
                 type="submit"
                 class="usa-button usa-button-secondary"
+                tabindex=0
+                role="button"
                 formaction="{{ previous_button_link }}">
                 {{ "common.previous" | translate }}
               </button>
             {% else -%}
               <a
                 class="usa-button usa-button-secondary"
+                tabindex=0
+                role="button"
                 href="{{ previous_button_link }}">
                 {{ "common.previous" | translate }}
               </a>
@@ -63,6 +67,8 @@
           {% endif %}
           <a
             v-on:click="openModal('cancel')"
+            tabindex=0
+            role="button"
             class="action-group__action icon-link">
             {{ "common.cancel" | translate }}
           </a>


### PR DESCRIPTION
Throughout the application there is a Next button and a Cancel link at the bottom of each of the steps.  

 

There are a couple of things broken with these buttons and links.  First, the button needs to receive a role of button as it is actually an input.  This will inform a screen reader user that the object can be interacted with as opposed to typing in information.

The cancel link needs to receive tabindex=0, because although it is an anchor element it does not have an href and as such does not receive focus natively.  

Also, the visual order of the objects needs to match the order of the DOM, or vice versa.  Currently the logical flow is Next and then Cancel, which from an application perspective makes sense however then the cancel button should be to the right of the Next button not to the left.