### PR TITLE
Revert "Bump date-fns from 2.21.1 to 2.21.2"

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "ally.js": "^1.4.1",
     "autoprefixer": "^9.8.6",
     "babel-polyfill": "^6.26.0",
-    "date-fns": "^2.21.2",
+    "date-fns": "^2.21.1",
     "lodash": "^4.17.21",
     "ramda": "^0.27.1",
     "stickybits": "^3.7.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3563,10 +3563,10 @@ data-urls@^2.0.0:
     whatwg-mimetype "^2.3.0"
     whatwg-url "^8.0.0"
 
-date-fns@^2.21.2:
-  version "2.21.2"
-  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.21.2.tgz#9db92305cf00626e9122e56c72195b17725594aa"
-  integrity sha512-FMkG7pIPx64mGIpS2LOb3Wp3O606H/hatoiz7G0oiYWai1izdM4tF1dd7QABv2NogkIDI4wxsfLLFQSuVvDHgA==
+date-fns@^2.21.1:
+  version "2.21.1"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.21.1.tgz#679a4ccaa584c0706ea70b3fa92262ac3009d2b0"
+  integrity sha512-m1WR0xGiC6j6jNFAyW4Nvh4WxAi4JF4w9jRJwSI8nBmNcyZXPcP9VUQG+6gHQXAmqaGEKDKhOqAtENDC941UkA==
 
 de-indent@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
This reverts commit 58a86de4451adbda3ec9e94198c4fa4c10eced2e.

This should fix Internet Explorer 11 polyfill issues that we were experiencing this morning.

Ticket: AT-6202